### PR TITLE
Added copyright footer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -103,3 +103,5 @@ Please refer to our [CONTRIBUTING](CONTRIBUTING.md) file.
 
 # License
 This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
+
+Copyright 2020 Expedia, Inc.


### PR DESCRIPTION
Also, is there a reason the filename is `readme.md` instead of `README.md`? Doesn't make much difference but the latter is more common across our OSS projects.