### PR TITLE
Integrated with Mockito 3.4.0+

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,7 +15,7 @@ indent_size = 4
 end_of_line = lf
 insert_final_newline = true
 
-[*.{yaml,yml}]
+[*.{yaml,yml,xml}]
 charset = utf-8
 indent_style = space
 indent_size = 2

--- a/molten-bom/pom.xml
+++ b/molten-bom/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.expediagroup.molten</groupId>
     <artifactId>molten-platform</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../molten-platform/pom.xml</relativePath>
   </parent>
 

--- a/molten-bom/pom.xml
+++ b/molten-bom/pom.xml
@@ -109,6 +109,12 @@
       </dependency>
       <dependency>
         <groupId>com.expediagroup.molten</groupId>
+        <artifactId>molten-test-mockito-autoconfigure</artifactId>
+        <version>${project.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.expediagroup.molten</groupId>
         <artifactId>molten-trace-test</artifactId>
         <version>${project.version}</version>
         <scope>test</scope>

--- a/molten-cache/pom.xml
+++ b/molten-cache/pom.xml
@@ -5,7 +5,7 @@
   <parent>
 	<groupId>com.expediagroup.molten</groupId>
     <artifactId>molten-root</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../molten-root/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/molten-cache/src/test/java/com/hotels/molten/cache/NamedReactiveCacheTest.java
+++ b/molten-cache/src/test/java/com/hotels/molten/cache/NamedReactiveCacheTest.java
@@ -18,13 +18,14 @@ package com.hotels.molten.cache;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.time.Duration;
 import java.util.function.Function;
 
 import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -32,6 +33,7 @@ import reactor.test.StepVerifier;
 /**
  * Unit test for {@link NamedReactiveCache}.
  */
+@Listeners(MockitoTestNGListener.class)
 public class NamedReactiveCacheTest {
     private static final int KEY = 1;
     private static final String VALUE = "one";
@@ -44,7 +46,6 @@ public class NamedReactiveCacheTest {
 
     @BeforeMethod
     public void initContext() {
-        initMocks(this);
         namedReactiveCache = new NamedReactiveCache<>(cache, CACHENAME, TTL);
     }
 

--- a/molten-cache/src/test/java/com/hotels/molten/cache/ReactiveCaffeineCacheTest.java
+++ b/molten-cache/src/test/java/com/hotels/molten/cache/ReactiveCaffeineCacheTest.java
@@ -19,11 +19,12 @@ package com.hotels.molten.cache;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import com.github.benmanes.caffeine.cache.Cache;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.testng.annotations.BeforeMethod;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -31,18 +32,14 @@ import reactor.test.StepVerifier;
 /**
  * Unit test for {@link ReactiveCaffeineCache}.
  */
+@Listeners(MockitoTestNGListener.class)
 public class ReactiveCaffeineCacheTest {
     private static final String VALUE = "one";
     private static final int KEY = 1;
     @Mock
     private Cache<Integer, String> cache;
+    @InjectMocks
     private ReactiveCaffeineCache<Integer, String> reactiveCache;
-
-    @BeforeMethod
-    public void initContext() {
-        initMocks(this);
-        reactiveCache = new ReactiveCaffeineCache<>(cache);
-    }
 
     @Test
     public void shouldDelegateGetLazily() {

--- a/molten-cache/src/test/java/com/hotels/molten/cache/ReactiveGuavaCacheTest.java
+++ b/molten-cache/src/test/java/com/hotels/molten/cache/ReactiveGuavaCacheTest.java
@@ -19,11 +19,12 @@ package com.hotels.molten.cache;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import com.google.common.cache.Cache;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.testng.annotations.BeforeMethod;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -31,18 +32,14 @@ import reactor.test.StepVerifier;
 /**
  * Unit test for {@link ReactiveGuavaCache}.
  */
+@Listeners(MockitoTestNGListener.class)
 public class ReactiveGuavaCacheTest {
     private static final String VALUE = "one";
     private static final int KEY = 1;
     @Mock
     private Cache<Integer, String> cache;
+    @InjectMocks
     private ReactiveGuavaCache<Integer, String> reactiveCache;
-
-    @BeforeMethod
-    public void initContext() {
-        initMocks(this);
-        reactiveCache = new ReactiveGuavaCache<>(cache);
-    }
 
     @Test
     public void shouldDelegateGetLazily() {

--- a/molten-cache/src/test/java/com/hotels/molten/cache/ReactiveMapCacheTest.java
+++ b/molten-cache/src/test/java/com/hotels/molten/cache/ReactiveMapCacheTest.java
@@ -19,12 +19,13 @@ package com.hotels.molten.cache;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.Map;
 
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.testng.annotations.BeforeMethod;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -32,18 +33,14 @@ import reactor.test.StepVerifier;
 /**
  * Unit test for {@link ReactiveMapCache}.
  */
+@Listeners(MockitoTestNGListener.class)
 public class ReactiveMapCacheTest {
     private static final String VALUE = "one";
     private static final int KEY = 1;
     @Mock
     private Map<Integer, String> cache;
+    @InjectMocks
     private ReactiveMapCache<Integer, String> reactiveCache;
-
-    @BeforeMethod
-    public void initContext() {
-        initMocks(this);
-        reactiveCache = new ReactiveMapCache<>(cache);
-    }
 
     @Test
     public void shouldDelegateGetLazily() {

--- a/molten-cache/src/test/java/com/hotels/molten/cache/ReactiveReloadingCacheTest.java
+++ b/molten-cache/src/test/java/com/hotels/molten/cache/ReactiveReloadingCacheTest.java
@@ -35,9 +35,10 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.scheduler.VirtualTimeScheduler;
@@ -52,6 +53,7 @@ import com.hotels.molten.test.TestClock;
  * Unit test for {@link ReactiveReloadingCache}.
  */
 @Slf4j
+@Listeners(MockitoTestNGListener.class)
 public class ReactiveReloadingCacheTest {
     private static final int KEY = 1;
     private static final String VALUE = "1";
@@ -73,7 +75,6 @@ public class ReactiveReloadingCacheTest {
     @BeforeMethod
     public void initContext() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
-        MockitoAnnotations.initMocks(this);
         meterRegistry = new SimpleMeterRegistry();
         cache = new ConcurrentHashMap<>();
         scheduler = VirtualTimeScheduler.create();

--- a/molten-cache/src/test/java/com/hotels/molten/cache/metrics/CaffeineCacheStatsInstrumenterTest.java
+++ b/molten-cache/src/test/java/com/hotels/molten/cache/metrics/CaffeineCacheStatsInstrumenterTest.java
@@ -30,9 +30,10 @@ import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 import com.hotels.molten.core.metrics.MoltenMetrics;
@@ -40,6 +41,7 @@ import com.hotels.molten.core.metrics.MoltenMetrics;
 /**
  * Unit test for {@link CaffeineCacheStatsInstrumenter}.
  */
+@Listeners(MockitoTestNGListener.class)
 public class CaffeineCacheStatsInstrumenterTest {
     private CaffeineCacheStatsInstrumenter instrumenter;
     private MeterRegistry meterRegistry;
@@ -49,7 +51,6 @@ public class CaffeineCacheStatsInstrumenterTest {
     @BeforeMethod
     public void initContext() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
-        MockitoAnnotations.initMocks(this);
         meterRegistry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
         instrumenter = new CaffeineCacheStatsInstrumenter(meterRegistry, "pre.fix");
     }

--- a/molten-cache/src/test/java/com/hotels/molten/cache/resilience/ResilientReactiveCacheTest.java
+++ b/molten-cache/src/test/java/com/hotels/molten/cache/resilience/ResilientReactiveCacheTest.java
@@ -22,7 +22,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.time.Duration;
 import java.util.concurrent.TimeoutException;
@@ -34,8 +33,10 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.assertj.core.api.Assertions;
 import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -48,6 +49,7 @@ import com.hotels.molten.test.AssertSubscriber;
 /**
  * Unit test for {@link ResilientReactiveCache}.
  */
+@Listeners(MockitoTestNGListener.class)
 public class ResilientReactiveCacheTest {
     private static final Long KEY = 1L;
     private static final String VALUE = "value";
@@ -59,11 +61,9 @@ public class ResilientReactiveCacheTest {
     private VirtualTimeScheduler scheduler;
     private String cacheName;
 
-    @SuppressWarnings("unchecked")
     @BeforeMethod
     public void initContext() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
-        initMocks(this);
         meterRegistry = new SimpleMeterRegistry();
         scheduler = VirtualTimeScheduler.create();
         VirtualTimeScheduler.set(scheduler);

--- a/molten-cache/src/test/java/com/hotels/molten/cache/resilience/ResilientSharedReactiveCacheTest.java
+++ b/molten-cache/src/test/java/com/hotels/molten/cache/resilience/ResilientSharedReactiveCacheTest.java
@@ -16,7 +16,6 @@
 
 package com.hotels.molten.cache.resilience;
 
-import static com.hotels.molten.test.mockito.ReactiveMockitoAnnotations.initMocks;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -26,32 +25,33 @@ import java.util.concurrent.atomic.AtomicInteger;
 import io.github.resilience4j.bulkhead.BulkheadFullException;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import com.hotels.molten.cache.ReactiveCache;
 import com.hotels.molten.test.AssertSubscriber;
-import com.hotels.molten.test.mockito.ReactiveMock;
 
 /**
  * Unit test for {@link ResilientSharedReactiveCache}.
  */
+@ExtendWith(MockitoExtension.class)
 public class ResilientSharedReactiveCacheTest {
     private static final Long KEY = 1L;
     private static final String VALUE = "value";
     private static final String CACHE_NAME = "cacheName";
     private static final AtomicInteger IDX = new AtomicInteger();
     private ResilientSharedReactiveCache<Long, String> resilientCache;
-    @ReactiveMock
+    @Mock
     private ReactiveCache<Long, String> cache;
     private MeterRegistry meterRegistry;
 
-    @SuppressWarnings("unchecked")
-    @BeforeMethod
+    @BeforeEach
     public void initContext() {
-        initMocks(this);
         meterRegistry = new SimpleMeterRegistry();
     }
 

--- a/molten-cache/src/test/java/com/hotels/molten/cache/resilience/RetryingReactiveCacheTest.java
+++ b/molten-cache/src/test/java/com/hotels/molten/cache/resilience/RetryingReactiveCacheTest.java
@@ -26,9 +26,12 @@ import java.time.Duration;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 import reactor.test.scheduler.VirtualTimeScheduler;
@@ -38,35 +41,33 @@ import com.hotels.molten.cache.ReactiveCache;
 import com.hotels.molten.core.metrics.MoltenMetrics;
 import com.hotels.molten.test.AssertSubscriber;
 import com.hotels.molten.test.UnstableMono;
-import com.hotels.molten.test.mockito.ReactiveMock;
-import com.hotels.molten.test.mockito.ReactiveMockitoAnnotations;
 
 /**
  * Unit test for {@link RetryingReactiveCache}.
  */
+@ExtendWith(MockitoExtension.class)
 public class RetryingReactiveCacheTest {
     private static final String KEY = "key";
     private static final String VALUE = "value";
     private static final String CACHE_NAME = "cacheName";
     private static final Duration RETRY_DELAY = Duration.ofMillis(50);
     private RetryingReactiveCache<String, String> retryingReactiveCache;
-    @ReactiveMock
+    @Mock
     private ReactiveCache<String, String> cache;
     private MeterRegistry meterRegistry;
     private VirtualTimeScheduler scheduler;
 
     @SuppressWarnings("unchecked")
-    @BeforeMethod
+    @BeforeEach
     public void initContext() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
-        ReactiveMockitoAnnotations.initMocks(this);
         meterRegistry = new SimpleMeterRegistry();
         scheduler = VirtualTimeScheduler.create();
         VirtualTimeScheduler.set(scheduler);
         retryingReactiveCache = new RetryingReactiveCache<>(cache, Retry.fixedDelay(2, RETRY_DELAY), meterRegistry, CACHE_NAME);
     }
 
-    @AfterMethod
+    @AfterEach
     public void clearContext() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
         VirtualTimeScheduler.reset();

--- a/molten-core/pom.xml
+++ b/molten-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.expediagroup.molten</groupId>
     <artifactId>molten-root</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../molten-root/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/molten-core/src/test/java/com/hotels/molten/core/collapser/FanOutRequestCollapserTest.java
+++ b/molten-core/src/test/java/com/hotels/molten/core/collapser/FanOutRequestCollapserTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -50,11 +51,12 @@ import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.testng.MockitoTestNGListener;
 import org.slf4j.MDC;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Ignore;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -72,6 +74,7 @@ import com.hotels.molten.test.AssertSubscriber;
  */
 @SuppressWarnings("unchecked")
 @Slf4j
+@Listeners(MockitoTestNGListener.class)
 public class FanOutRequestCollapserTest {
     private static final int CONTEXT_A = 1;
     private static final String RESULT_A = "1";
@@ -102,7 +105,6 @@ public class FanOutRequestCollapserTest {
         MoltenCore.initialize();
         MoltenMDC.initialize();
         MDC.clear();
-        MockitoAnnotations.initMocks(this);
         clock = new MockClock();
         meterRegistry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, clock);
 
@@ -473,7 +475,7 @@ public class FanOutRequestCollapserTest {
 
     @Test
     public void should_be_able_to_shutdown_gracefully() {
-        when(bulkProvider.apply((List<Integer>) argThat(contains(CONTEXT_A, CONTEXT_B))))
+        lenient().when(bulkProvider.apply((List<Integer>) argThat(contains(CONTEXT_A, CONTEXT_B))))
             .thenReturn(Mono.just(List.of(RESULT_A)));
 
         AssertSubscriber<String> subscriber1 = AssertSubscriber.create();

--- a/molten-core/src/test/java/com/hotels/molten/core/collapser/RequestCollapserTest.java
+++ b/molten-core/src/test/java/com/hotels/molten/core/collapser/RequestCollapserTest.java
@@ -38,10 +38,11 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.testng.MockitoTestNGListener;
 import org.slf4j.MDC;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -58,6 +59,7 @@ import com.hotels.molten.test.AssertSubscriber;
  * Unit test for {@link RequestCollapser}.
  */
 @Slf4j
+@Listeners(MockitoTestNGListener.class)
 public class RequestCollapserTest {
     private static final int CONTEXT = 1;
     private static final String RESULT = "result";
@@ -78,7 +80,6 @@ public class RequestCollapserTest {
         MDC.clear();
         MoltenCore.initialize();
         MoltenMDC.initialize();
-        MockitoAnnotations.initMocks(this);
         meterRegistry = new SimpleMeterRegistry();
         scheduler = VirtualTimeScheduler.create();
         timeoutScheduler = VirtualTimeScheduler.create();

--- a/molten-dependencies/pom.xml
+++ b/molten-dependencies/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.expediagroup.molten</groupId>
     <artifactId>molten-platform</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../molten-platform/pom.xml</relativePath>
   </parent>
 

--- a/molten-health/pom.xml
+++ b/molten-health/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.expediagroup.molten</groupId>
     <artifactId>molten-root</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../molten-root/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/molten-health/src/main/java/com/hotels/molten/healthcheck/CircuitBasedFlowMarker.java
+++ b/molten-health/src/main/java/com/hotels/molten/healthcheck/CircuitBasedFlowMarker.java
@@ -59,8 +59,8 @@ public final class CircuitBasedFlowMarker implements HealthIndicator, FlowMarker
     }
 
     @Override
-    public void failure(Throwable ex) {
-        circuitBreaker.onError(0, TimeUnit.MILLISECONDS, ex);
+    public void failure(Throwable throwable) {
+        circuitBreaker.onError(0, TimeUnit.MILLISECONDS, throwable);
     }
 
 }

--- a/molten-health/src/main/java/com/hotels/molten/healthcheck/FlowMarker.java
+++ b/molten-health/src/main/java/com/hotels/molten/healthcheck/FlowMarker.java
@@ -28,6 +28,8 @@ public interface FlowMarker {
 
     /**
      * Marks a failed step.
+     *
+     * @param throwable the cause of the failure
      */
-    void failure(Throwable ex);
+    void failure(Throwable throwable);
 }

--- a/molten-health/src/test/java/com/hotels/molten/healthcheck/resilience4j/HealthIndicatorOverCircuitBreakerTest.java
+++ b/molten-health/src/test/java/com/hotels/molten/healthcheck/resilience4j/HealthIndicatorOverCircuitBreakerTest.java
@@ -27,8 +27,9 @@ import io.github.resilience4j.core.EventConsumer;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import reactor.test.StepVerifier;
 
@@ -37,6 +38,7 @@ import com.hotels.molten.healthcheck.Status;
 /**
  * Unit test for {@link HealthIndicatorOverCircuitBreaker}.
  */
+@Listeners(MockitoTestNGListener.class)
 public class HealthIndicatorOverCircuitBreakerTest {
     private static final String A_NAME = "any";
     @Mock
@@ -49,7 +51,6 @@ public class HealthIndicatorOverCircuitBreakerTest {
 
     @BeforeMethod
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
         when(circuitBreaker.getEventPublisher()).thenReturn(eventPublisher);
         when(circuitBreaker.getState()).thenReturn(CircuitBreaker.State.CLOSED);
         when(circuitBreaker.getName()).thenReturn(A_NAME);

--- a/molten-http-client/pom.xml
+++ b/molten-http-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.expediagroup.molten</groupId>
     <artifactId>molten-root</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../molten-root/pom.xml</relativePath>
   </parent>
   <artifactId>molten-http-client</artifactId>

--- a/molten-http-client/src/test/java/com/hotels/molten/http/client/BulkheadingReactiveProxyFactoryTest.java
+++ b/molten-http-client/src/test/java/com/hotels/molten/http/client/BulkheadingReactiveProxyFactoryTest.java
@@ -30,9 +30,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import io.github.resilience4j.bulkhead.BulkheadFullException;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -44,6 +45,7 @@ import com.hotels.molten.test.AssertSubscriber;
 /**
  * Unit test for {@link BulkheadingReactiveProxyFactory}.
  */
+@Listeners(MockitoTestNGListener.class)
 public class BulkheadingReactiveProxyFactoryTest {
     private static final AtomicInteger ISO_GRP_IDX = new AtomicInteger();
     private static final int REQUEST_PARAM = 1;
@@ -59,7 +61,6 @@ public class BulkheadingReactiveProxyFactoryTest {
     public void initContext() {
         scheduler = VirtualTimeScheduler.create();
         VirtualTimeScheduler.set(scheduler);
-        MockitoAnnotations.initMocks(this);
         meterRegistry = new SimpleMeterRegistry();
     }
 

--- a/molten-http-client/src/test/java/com/hotels/molten/http/client/CircuitBreakingReactiveProxyFactoryTest.java
+++ b/molten-http-client/src/test/java/com/hotels/molten/http/client/CircuitBreakingReactiveProxyFactoryTest.java
@@ -28,36 +28,37 @@ import java.time.Duration;
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import com.hotels.molten.core.metrics.MoltenMetrics;
 import com.hotels.molten.healthcheck.HealthIndicatorWatcher;
-import com.hotels.molten.test.mockito.ReactiveMock;
-import com.hotels.molten.test.mockito.ReactiveMockitoAnnotations;
 
 /**
  * Unit test for {@link CircuitBreakingReactiveProxyFactory}.
  */
+@ExtendWith(MockitoExtension.class)
 public class CircuitBreakingReactiveProxyFactoryTest {
     private static final String OK = "ok";
     private static final String CLIENT_ID = "clientId";
-    @ReactiveMock
+    @Mock
     private Camoo service;
     private HealthIndicatorWatcher watcher = indicator -> { };
     private SimpleMeterRegistry meterRegistry;
 
-    @BeforeMethod
+    @BeforeEach
     public void initContext() {
-        ReactiveMockitoAnnotations.initMocks(this);
         meterRegistry = new SimpleMeterRegistry();
     }
 
-    @AfterMethod
+    @AfterEach
     public void clearContext() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
     }

--- a/molten-http-client/src/test/java/com/hotels/molten/http/client/HttpServiceInvocationExceptionHandlingReactiveProxyFactoryTest.java
+++ b/molten-http-client/src/test/java/com/hotels/molten/http/client/HttpServiceInvocationExceptionHandlingReactiveProxyFactoryTest.java
@@ -32,9 +32,10 @@ import java.net.SocketTimeoutException;
 import okhttp3.MediaType;
 import okhttp3.ResponseBody;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -43,6 +44,7 @@ import retrofit2.Response;
 /**
  * Unit test for {@link HttpServiceInvocationExceptionHandlingReactiveProxyFactory}.
  */
+@Listeners(MockitoTestNGListener.class)
 public class HttpServiceInvocationExceptionHandlingReactiveProxyFactoryTest {
     private static final ResponseBody RESPONSE_BODY = ResponseBody.create("", MediaType.parse("application/json"));
     private static final String EXCEPTION_MESSAGE_PREFIX = "service=com.hotels.molten.http.client.Camoo";
@@ -52,7 +54,6 @@ public class HttpServiceInvocationExceptionHandlingReactiveProxyFactoryTest {
 
     @BeforeMethod
     public void initContext() {
-        MockitoAnnotations.initMocks(this);
         proxyFactory = new HttpServiceInvocationExceptionHandlingReactiveProxyFactory(DEFAULT_FAILED_RESPONSE_PREDICATE);
     }
 

--- a/molten-http-client/src/test/java/com/hotels/molten/http/client/InstrumentedReactiveProxyFactoryTest.java
+++ b/molten-http-client/src/test/java/com/hotels/molten/http/client/InstrumentedReactiveProxyFactoryTest.java
@@ -29,37 +29,38 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import com.hotels.molten.core.metrics.MoltenMetrics;
-import com.hotels.molten.test.mockito.ReactiveMock;
-import com.hotels.molten.test.mockito.ReactiveMockitoAnnotations;
 
 /**
  * Unit test for {@link InstrumentedReactiveProxyFactory}.
  */
+@ExtendWith(MockitoExtension.class)
 public class InstrumentedReactiveProxyFactoryTest {
     private static final String CLIENT_ID = "clientId";
     private InstrumentedReactiveProxyFactory proxyFactory;
-    @ReactiveMock
+    @Mock
     private Camoo service;
     private MockClock clock;
     private MeterRegistry meterRegistry;
 
-    @BeforeMethod
+    @BeforeEach
     public void initContext() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
-        ReactiveMockitoAnnotations.initMocks(this);
         clock = new MockClock();
         meterRegistry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, clock);
         proxyFactory = new InstrumentedReactiveProxyFactory(meterRegistry, CLIENT_ID, "raw");
     }
 
-    @AfterMethod
+    @AfterEach
     public void clearContext() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
     }

--- a/molten-http-client/src/test/java/com/hotels/molten/http/client/RetryingReactiveProxyFactoryTest.java
+++ b/molten-http-client/src/test/java/com/hotels/molten/http/client/RetryingReactiveProxyFactoryTest.java
@@ -23,11 +23,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
@@ -37,9 +37,11 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -50,6 +52,7 @@ import com.hotels.molten.core.metrics.MoltenMetrics;
  * Unit test for {@link RetryingReactiveProxyFactory}.
  */
 @Slf4j
+@Listeners(MockitoTestNGListener.class)
 public class RetryingReactiveProxyFactoryTest {
     private static final String CLIENT_ID = "clientId";
     private RetryingReactiveProxyFactory proxyFactory;
@@ -63,10 +66,9 @@ public class RetryingReactiveProxyFactoryTest {
     @BeforeMethod
     public void initContext() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
-        initMocks(this);
         meterRegistry = new SimpleMeterRegistry();
         proxyFactory = new RetryingReactiveProxyFactory(2, CLIENT_ID).withMetrics(meterRegistry);
-        when(appender.getName()).thenReturn("MOCK");
+        lenient().when(appender.getName()).thenReturn("MOCK");
         callLogger.addAppender(appender);
     }
 

--- a/molten-http-client/src/test/java/com/hotels/molten/http/client/TimeoutReactiveProxyFactoryTest.java
+++ b/molten-http-client/src/test/java/com/hotels/molten/http/client/TimeoutReactiveProxyFactoryTest.java
@@ -27,40 +27,41 @@ import java.time.Duration;
 import java.util.concurrent.TimeoutException;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import com.hotels.molten.core.metrics.MoltenMetrics;
-import com.hotels.molten.test.mockito.ReactiveMock;
-import com.hotels.molten.test.mockito.ReactiveMockitoAnnotations;
 
 /**
  * Unit test for {@link TimeoutReactiveProxyFactory}.
  */
+@ExtendWith(MockitoExtension.class)
 public class TimeoutReactiveProxyFactoryTest {
     private static final String OK = "ok";
     private static final Duration TIMEOUT = Duration.ofMillis(1000);
     private static final String CLIENT_ID = "clientId";
-    @ReactiveMock
+    @Mock
     private Camoo service;
     private TimeoutReactiveProxyFactory proxyFactory;
     private Camoo wrappedService;
     private MeterRegistry meterRegistry;
 
-    @BeforeMethod
+    @BeforeEach
     public void initContext() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
-        ReactiveMockitoAnnotations.initMocks(this);
         proxyFactory = new TimeoutReactiveProxyFactory(TIMEOUT);
         meterRegistry = MeterRegistrySupport.simpleRegistry();
         proxyFactory.withMetrics(meterRegistry, CLIENT_ID, "raw");
         wrappedService = proxyFactory.wrap(Camoo.class, service);
     }
 
-    @AfterMethod
+    @AfterEach
     public void clearContext() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
     }

--- a/molten-http-client/src/test/java/com/hotels/molten/http/client/listener/CollectingDelegatingEventsListenerTest.java
+++ b/molten-http-client/src/test/java/com/hotels/molten/http/client/listener/CollectingDelegatingEventsListenerTest.java
@@ -30,13 +30,15 @@ import okhttp3.Call;
 import okhttp3.Connection;
 import okhttp3.HttpUrl;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 /**
  * Test for {@link CollectingDelegatingEventsListener}.
  */
+@Listeners(MockitoTestNGListener.class)
 public class CollectingDelegatingEventsListenerTest {
 
     @Mock
@@ -54,7 +56,6 @@ public class CollectingDelegatingEventsListenerTest {
 
     @BeforeMethod
     public void init() {
-        MockitoAnnotations.initMocks(this);
         AtomicLong now = new AtomicLong();
         when(clock.millis()).thenAnswer(ie -> now.getAndAdd(100L));
     }

--- a/molten-http-client/src/test/java/com/hotels/molten/http/client/listener/DurationMetricsReporterHandlerTest.java
+++ b/molten-http-client/src/test/java/com/hotels/molten/http/client/listener/DurationMetricsReporterHandlerTest.java
@@ -26,9 +26,10 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import okhttp3.HttpUrl;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 import com.hotels.molten.core.metrics.MoltenMetrics;
@@ -36,6 +37,7 @@ import com.hotels.molten.core.metrics.MoltenMetrics;
 /**
  * Test for {@link DurationMetricsReporterHandler}.
  */
+@Listeners(MockitoTestNGListener.class)
 public class DurationMetricsReporterHandlerTest {
     private static final String CLIENT_ID = "clientId";
     private MeterRegistry meterRegistry;
@@ -45,7 +47,6 @@ public class DurationMetricsReporterHandlerTest {
 
     @BeforeMethod
     public void init() {
-        MockitoAnnotations.initMocks(this);
         meterRegistry = new SimpleMeterRegistry();
         handler = new DurationMetricsReporterHandler(meterRegistry, CLIENT_ID);
     }

--- a/molten-http-client/src/test/java/com/hotels/molten/http/client/listener/HttpMetricsReporterHandlerTest.java
+++ b/molten-http-client/src/test/java/com/hotels/molten/http/client/listener/HttpMetricsReporterHandlerTest.java
@@ -23,13 +23,13 @@ import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.ImmutableMultimap;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import okhttp3.HttpUrl;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 import com.hotels.molten.core.metrics.MoltenMetrics;
@@ -37,18 +37,16 @@ import com.hotels.molten.core.metrics.MoltenMetrics;
 /**
  * Unit test for {@link HttpMetricsReporterHandler}.
  */
+@Listeners(MockitoTestNGListener.class)
 public class HttpMetricsReporterHandlerTest {
     private static final String CLIENT_ID = "clientId";
     private MeterRegistry meterRegistry;
     @Mock
     private HttpUrl httpUrl;
-    @Mock
-    private Timer timer;
     private HttpMetricsReporterHandler handler;
 
     @BeforeMethod
     public void init() {
-        MockitoAnnotations.initMocks(this);
         meterRegistry = new SimpleMeterRegistry();
         handler = new HttpMetricsReporterHandler(meterRegistry, CLIENT_ID);
     }

--- a/molten-http-client/src/test/java/com/hotels/molten/http/client/metrics/ConnectionPoolInstrumenterTest.java
+++ b/molten-http-client/src/test/java/com/hotels/molten/http/client/metrics/ConnectionPoolInstrumenterTest.java
@@ -24,8 +24,9 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import okhttp3.ConnectionPool;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 import com.hotels.molten.core.metrics.MoltenMetrics;
@@ -33,6 +34,7 @@ import com.hotels.molten.core.metrics.MoltenMetrics;
 /**
  * Unit test for {@link ConnectionPoolInstrumenter}.
  */
+@Listeners(MockitoTestNGListener.class)
 public class ConnectionPoolInstrumenterTest {
     private static final String CLIENT_ID = "clientId";
     private ConnectionPoolInstrumenter instrumenter;
@@ -42,7 +44,6 @@ public class ConnectionPoolInstrumenterTest {
 
     @BeforeMethod
     public void initContext() {
-        MockitoAnnotations.initMocks(this);
         meterRegistry = new SimpleMeterRegistry();
         instrumenter = new ConnectionPoolInstrumenter(meterRegistry, CLIENT_ID);
         when(connectionPool.connectionCount()).thenReturn(3);

--- a/molten-http-client/src/test/java/com/hotels/molten/http/client/metrics/DispatcherInstrumenterTest.java
+++ b/molten-http-client/src/test/java/com/hotels/molten/http/client/metrics/DispatcherInstrumenterTest.java
@@ -24,8 +24,9 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import okhttp3.Dispatcher;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 import com.hotels.molten.core.metrics.MoltenMetrics;
@@ -33,6 +34,7 @@ import com.hotels.molten.core.metrics.MoltenMetrics;
 /**
  * Unit test for {@link DispatcherInstrumenter}.
  */
+@Listeners(MockitoTestNGListener.class)
 public class DispatcherInstrumenterTest {
     private static final String CLIENT_ID = "clientId";
     private DispatcherInstrumenter instrumenter;
@@ -42,7 +44,6 @@ public class DispatcherInstrumenterTest {
 
     @BeforeMethod
     public void initContext() {
-        MockitoAnnotations.initMocks(this);
         meterRegistry = new SimpleMeterRegistry();
         instrumenter = new DispatcherInstrumenter(meterRegistry, CLIENT_ID);
         when(dispatcher.queuedCallsCount()).thenReturn(3);

--- a/molten-http-client/src/test/java/com/hotels/molten/http/client/metrics/MicrometerHttpClientMetricsRecorderTest.java
+++ b/molten-http-client/src/test/java/com/hotels/molten/http/client/metrics/MicrometerHttpClientMetricsRecorderTest.java
@@ -26,9 +26,10 @@ import java.util.concurrent.TimeUnit;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.mockito.MockitoAnnotations;
+import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 import com.hotels.molten.core.metrics.MoltenMetrics;
@@ -36,6 +37,7 @@ import com.hotels.molten.core.metrics.MoltenMetrics;
 /**
  * Unit test for {@link MicrometerHttpClientMetricsRecorder}.
  */
+@Listeners(MockitoTestNGListener.class)
 public class MicrometerHttpClientMetricsRecorderTest {
     private static final String CLIENT_ID = "clientId";
     private MicrometerHttpClientMetricsRecorder recorder;
@@ -43,7 +45,6 @@ public class MicrometerHttpClientMetricsRecorderTest {
 
     @BeforeMethod
     public void initContext() {
-        MockitoAnnotations.initMocks(this);
         meterRegistry = new SimpleMeterRegistry();
         recorder = new MicrometerHttpClientMetricsRecorder(meterRegistry, CLIENT_ID);
     }

--- a/molten-http-client/src/test/java/com/hotels/molten/http/client/tracking/MdcBasedMessageGroupIdTrackingHeaderSupplierTest.java
+++ b/molten-http-client/src/test/java/com/hotels/molten/http/client/tracking/MdcBasedMessageGroupIdTrackingHeaderSupplierTest.java
@@ -18,7 +18,6 @@ package com.hotels.molten.http.client.tracking;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.Optional;
 
@@ -39,7 +38,6 @@ public class MdcBasedMessageGroupIdTrackingHeaderSupplierTest {
 
     @BeforeMethod
     public void initContext() {
-        initMocks(this);
         provider = new MdcBasedMessageGroupIdTrackingHeaderSupplier(HEADER_NAME);
     }
 

--- a/molten-http-client/src/test/java/com/hotels/molten/http/client/tracking/MdcBasedSessionIdTrackingHeaderSupplierTest.java
+++ b/molten-http-client/src/test/java/com/hotels/molten/http/client/tracking/MdcBasedSessionIdTrackingHeaderSupplierTest.java
@@ -18,7 +18,6 @@ package com.hotels.molten.http.client.tracking;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.Optional;
 
@@ -39,7 +38,6 @@ public class MdcBasedSessionIdTrackingHeaderSupplierTest {
 
     @BeforeMethod
     public void initContext() {
-        initMocks(this);
         provider = new MdcBasedSessionIdTrackingHeaderSupplier(HEADER_NAME);
     }
 

--- a/molten-metrics/pom.xml
+++ b/molten-metrics/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.expediagroup.molten</groupId>
         <artifactId>molten-root</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../molten-root/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/molten-metrics/src/test/java/com/hotels/molten/metrics/InstrumentedFluxOperatorTest.java
+++ b/molten-metrics/src/test/java/com/hotels/molten/metrics/InstrumentedFluxOperatorTest.java
@@ -21,7 +21,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.concurrent.TimeUnit;
 
@@ -54,7 +53,6 @@ public class InstrumentedFluxOperatorTest {
     @BeforeMethod
     public void init() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
-        initMocks(this);
         meterRegistry = new SimpleMeterRegistry();
     }
 

--- a/molten-metrics/src/test/java/com/hotels/molten/metrics/InstrumentedMonoOperatorTest.java
+++ b/molten-metrics/src/test/java/com/hotels/molten/metrics/InstrumentedMonoOperatorTest.java
@@ -21,7 +21,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.concurrent.TimeUnit;
 
@@ -54,7 +53,6 @@ public class InstrumentedMonoOperatorTest {
     @BeforeMethod
     public void init() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
-        initMocks(this);
         meterRegistry = new SimpleMeterRegistry();
     }
 

--- a/molten-metrics/src/test/java/com/hotels/molten/metrics/resilience/BulkheadInstrumenterTest.java
+++ b/molten-metrics/src/test/java/com/hotels/molten/metrics/resilience/BulkheadInstrumenterTest.java
@@ -18,7 +18,6 @@ package com.hotels.molten.metrics.resilience;
 
 import static com.hotels.molten.core.metrics.MetricsSupport.GRAPHITE_ID;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.time.Duration;
 
@@ -53,7 +52,6 @@ public class BulkheadInstrumenterTest {
 
     @BeforeMethod
     public void initContext() {
-        initMocks(this);
         meterRegistry = new SimpleMeterRegistry();
     }
 

--- a/molten-platform/pom.xml
+++ b/molten-platform/pom.xml
@@ -56,7 +56,7 @@
     <testng.version>7.3.0</testng.version>
     <assertj.version>3.18.1</assertj.version>
     <hamcrest.version>2.0.0.0</hamcrest.version>
-    <mockito.version>3.3.3</mockito.version><!-- 3.4.0 has a breaking change -->
+    <mockito.version>3.4.0</mockito.version>
     <byte-buddy.version>1.10.19</byte-buddy.version>
     <janino.version>3.1.2</janino.version>
     <junit.jupiter.version>5.7.0</junit.jupiter.version>

--- a/molten-platform/pom.xml
+++ b/molten-platform/pom.xml
@@ -35,7 +35,8 @@
     <checkstyle.skip>false</checkstyle.skip>
     <checkstyle.rules.directory>build</checkstyle.rules.directory>
     <checkstyle.config.location>${checkstyle.rules.directory}/checkstyle_rules.xml</checkstyle.config.location>
-    <checkstyle.default.suppressions.location>${checkstyle.rules.directory}/suppressions_defaults.xml</checkstyle.default.suppressions.location>
+    <checkstyle.default.suppressions.location>${checkstyle.rules.directory}/suppressions_defaults.xml
+    </checkstyle.default.suppressions.location>
     <checkstyle.suppressions.location>${checkstyle.rules.directory}/suppressions.xml</checkstyle.suppressions.location>
     <checkstyle.considered.severity>error</checkstyle.considered.severity>
     <checkstyle.considered.match>true</checkstyle.considered.match>
@@ -57,6 +58,7 @@
     <assertj.version>3.18.1</assertj.version>
     <hamcrest.version>2.0.0.0</hamcrest.version>
     <mockito.version>3.7.0</mockito.version>
+    <mockito-testng.version>0.2.5</mockito-testng.version>
     <byte-buddy.version>1.10.19</byte-buddy.version>
     <janino.version>3.1.2</janino.version>
     <junit.jupiter.version>5.7.0</junit.jupiter.version>
@@ -71,10 +73,10 @@
         <artifactId>guava</artifactId>
         <version>${guava.version}</version>
         <exclusions>
-           <exclusion>
-             <groupId>org.checkerframework</groupId>
-             <artifactId>checker-compat-qual</artifactId>
-           </exclusion>
+          <exclusion>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>checker-compat-qual</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -256,6 +258,12 @@
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
+        <artifactId>mockito-testng</artifactId>
+        <version>${mockito-testng.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
         <artifactId>mockito-junit-jupiter</artifactId>
         <version>${mockito.version}</version>
         <scope>test</scope>
@@ -267,6 +275,10 @@
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-testng</artifactId>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
@@ -716,27 +728,39 @@
               <skip>${skip.platform.banned.dependency.check}</skip>
               <rules>
                 <bannedDependencies>
-                  <message>Sorry, I am unable to provide you with JRuby artifacts as they are banned from use at Hotels.com.  Please contact Árpád Tomán if you have a real requirement to use JRuby</message>
+                  <message>Sorry, I am unable to provide you with JRuby artifacts as they are banned from use at
+                    Hotels.com. Please contact Árpád Tomán if you have a real requirement to use JRuby
+                  </message>
                   <excludes>
                     <exclude>org.jruby:jruby</exclude>
                   </excludes>
                 </bannedDependencies>
                 <bannedDependencies>
-                  <message>Sorry, I am unable to provide you with commons-logging as this artifact is banned from use at Hotels.com as we favor the logback framework for logging.  Logback natively implements the SLF4J API and so ch.qos.logback:logback-classic:${logback.version} can be considered a direct drop-in replacement.</message>
+                  <message>Sorry, I am unable to provide you with commons-logging as this artifact is banned from use at
+                    Hotels.com as we favor the logback framework for logging. Logback natively implements the SLF4J API
+                    and so ch.qos.logback:logback-classic:${logback.version} can be considered a direct drop-in
+                    replacement.
+                  </message>
                   <excludes>
                     <exclude>commons-logging:commons-logging</exclude>
                     <exclude>org.apache.commons:commons-logging</exclude>
                   </excludes>
                 </bannedDependencies>
                 <bannedDependencies>
-                  <message>Sorry, I am unable to provide you with Log4J as this artifact is banned from use at Hotels.com as we favor the logback framework for logging.</message>
+                  <message>Sorry, I am unable to provide you with Log4J as this artifact is banned from use at
+                    Hotels.com as we favor the logback framework for logging.
+                  </message>
                   <excludes>
                     <exclude>log4j:log4j</exclude>
                   </excludes>
                   <searchTransitive>true</searchTransitive>
                 </bannedDependencies>
                 <bannedDependencies>
-                  <message>Sorry, I am unable to provide you with SLF4J artifacts as they are banned from use at Hotels.com as we favor the logback framework for logging.  Logback natively implements the SLF4J API and so ch.qos.logback:logback-classic:${logback.version} can be considered a direct drop-in replacement.</message>
+                  <message>Sorry, I am unable to provide you with SLF4J artifacts as they are banned from use at
+                    Hotels.com as we favor the logback framework for logging. Logback natively implements the SLF4J API
+                    and so ch.qos.logback:logback-classic:${logback.version} can be considered a direct drop-in
+                    replacement.
+                  </message>
                   <excludes>
                     <exclude>org.slf4j:slf4j-jcl</exclude>
                     <exclude>org.slf4j:slf4j-jdk14</exclude>
@@ -803,7 +827,8 @@
                   </excludes>
                 </bannedDependencies>
                 <bannedDependencies>
-                  <message>Please use cglib:cglib instead of org.sonatype.sisu.inject:cglib or cglib:cglib-nodep</message>
+                  <message>Please use cglib:cglib instead of org.sonatype.sisu.inject:cglib or cglib:cglib-nodep
+                  </message>
                   <excludes>
                     <exclude>org.sonatype.sisu.inject:cglib</exclude>
                     <exclude>cglib:cglib-nodep</exclude>
@@ -816,7 +841,8 @@
                   </excludes>
                 </bannedDependencies>
                 <bannedDependencies>
-                  <message>Please use org.aspectj:aspectjweaver instead of aspectj:aspectjrt or org.aspectj:aspectjrt</message>
+                  <message>Please use org.aspectj:aspectjweaver instead of aspectj:aspectjrt or org.aspectj:aspectjrt
+                  </message>
                   <excludes>
                     <exclude>aspectj:aspectjrt</exclude>
                     <exclude>org.aspectj:aspectjrt</exclude>
@@ -829,13 +855,17 @@
                   </excludes>
                 </bannedDependencies>
                 <bannedDependencies>
-                  <message>Please use commons-collections:commons-collections instead of org.apache.commons:commons-collections</message>
+                  <message>Please use commons-collections:commons-collections instead of
+                    org.apache.commons:commons-collections
+                  </message>
                   <excludes>
                     <exclude>org.apache.commons:commons-collections</exclude>
                   </excludes>
                 </bannedDependencies>
                 <bannedDependencies>
-                  <message>Please use commons-lang:commons-lang instead of org.apache.commons:commons-lang or org.apache:commons-lang</message>
+                  <message>Please use commons-lang:commons-lang instead of org.apache.commons:commons-lang or
+                    org.apache:commons-lang
+                  </message>
                   <excludes>
                     <exclude>org.apache:commons-lang</exclude>
                     <exclude>org.apache.commons:commons-lang</exclude>
@@ -860,13 +890,17 @@
                   </excludes>
                 </bannedDependencies>
                 <bannedDependencies>
-                  <message>Please exclude org.springframework:spring-asm because this dependency no longer exists in Spring 3.2+ and its content was moved to org.springframework:spring-core.</message>
+                  <message>Please exclude org.springframework:spring-asm because this dependency no longer exists in
+                    Spring 3.2+ and its content was moved to org.springframework:spring-core.
+                  </message>
                   <excludes>
                     <exclude>org.springframework:spring-asm</exclude>
                   </excludes>
                 </bannedDependencies>
                 <bannedDependencies>
-                  <message>Please exclude org.springframework:spring-transaction because it has been renamed in Spring 3.2+ to org.springframework:spring-tx.</message>
+                  <message>Please exclude org.springframework:spring-transaction because it has been renamed in Spring
+                    3.2+ to org.springframework:spring-tx.
+                  </message>
                   <excludes>
                     <exclude>org.springframework:spring-transaction</exclude>
                   </excludes>

--- a/molten-platform/pom.xml
+++ b/molten-platform/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.expediagroup.molten</groupId>
     <artifactId>molten-base</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/molten-platform/pom.xml
+++ b/molten-platform/pom.xml
@@ -56,7 +56,7 @@
     <testng.version>7.3.0</testng.version>
     <assertj.version>3.18.1</assertj.version>
     <hamcrest.version>2.0.0.0</hamcrest.version>
-    <mockito.version>3.4.0</mockito.version>
+    <mockito.version>3.7.0</mockito.version>
     <byte-buddy.version>1.10.19</byte-buddy.version>
     <janino.version>3.1.2</janino.version>
     <junit.jupiter.version>5.7.0</junit.jupiter.version>

--- a/molten-remote-cache/pom.xml
+++ b/molten-remote-cache/pom.xml
@@ -3,7 +3,7 @@
   <parent>
 	<groupId>com.expediagroup.molten</groupId>
     <artifactId>molten-root</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../molten-root/pom.xml</relativePath>
   </parent>
 

--- a/molten-remote-cache/src/test/java/com/hotels/molten/cache/redis/LettuceEventBasedHealthIndicatorTest.java
+++ b/molten-remote-cache/src/test/java/com/hotels/molten/cache/redis/LettuceEventBasedHealthIndicatorTest.java
@@ -28,8 +28,9 @@ import io.lettuce.core.event.connection.DisconnectedEvent;
 import io.lettuce.core.event.connection.ReconnectFailedEvent;
 import lombok.extern.slf4j.Slf4j;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import reactor.core.publisher.EmitterProcessor;
 import reactor.core.publisher.Flux;
@@ -43,6 +44,7 @@ import com.hotels.molten.test.AssertSubscriber;
  * Unit test for {@link LettuceEventBasedHealthIndicator}.
  */
 @Slf4j
+@Listeners(MockitoTestNGListener.class)
 public class LettuceEventBasedHealthIndicatorTest {
 
     private static final InetSocketAddress LOCAL = new InetSocketAddress("local", 1111);
@@ -55,7 +57,6 @@ public class LettuceEventBasedHealthIndicatorTest {
 
     @BeforeMethod
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
         events = EmitterProcessor.create();
         when(eventBus.get()).thenReturn(events);
     }

--- a/molten-remote-cache/src/test/java/com/hotels/molten/cache/redis/ReactiveRemoteRedisCacheTest.java
+++ b/molten-remote-cache/src/test/java/com/hotels/molten/cache/redis/ReactiveRemoteRedisCacheTest.java
@@ -20,16 +20,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.time.Duration;
 
 import io.lettuce.core.cluster.api.reactive.RedisAdvancedClusterReactiveCommands;
 import lombok.extern.slf4j.Slf4j;
 import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
 import org.slf4j.MDC;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
@@ -47,6 +48,7 @@ import com.hotels.molten.trace.test.AbstractTracingTest;
  * Unit test for {@link ReactiveRemoteRedisCache}.
  */
 @Slf4j
+@Listeners(MockitoTestNGListener.class)
 public class ReactiveRemoteRedisCacheTest extends AbstractTracingTest {
     private static final String KEY = "key";
     private static final String CACHE_NAME = "cacheName";
@@ -63,7 +65,6 @@ public class ReactiveRemoteRedisCacheTest extends AbstractTracingTest {
     @BeforeMethod
     public void initContext() {
         MoltenMDC.initialize();
-        initMocks(this);
         scheduler = VirtualTimeScheduler.create();
         VirtualTimeScheduler.set(scheduler);
     }

--- a/molten-remote-cache/src/test/java/com/hotels/molten/cache/redis/RetryingRedisConnectionProviderTest.java
+++ b/molten-remote-cache/src/test/java/com/hotels/molten/cache/redis/RetryingRedisConnectionProviderTest.java
@@ -19,7 +19,6 @@ package com.hotels.molten.cache.redis;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.time.Duration;
 import java.util.function.Supplier;
@@ -28,8 +27,10 @@ import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.cluster.api.reactive.RedisAdvancedClusterReactiveCommands;
 import lombok.extern.slf4j.Slf4j;
 import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -39,6 +40,7 @@ import reactor.test.scheduler.VirtualTimeScheduler;
  * Unit test for {@link RetryingRedisConnectionProvider}.
  */
 @Slf4j
+@Listeners(MockitoTestNGListener.class)
 public class RetryingRedisConnectionProviderTest {
 
     @Mock
@@ -52,7 +54,6 @@ public class RetryingRedisConnectionProviderTest {
 
     @BeforeMethod
     public void initContext() {
-        initMocks(this);
         scheduler = VirtualTimeScheduler.create();
         VirtualTimeScheduler.set(scheduler);
         connectionProvider = new RetryingRedisConnectionProvider(connectionSupplier);

--- a/molten-remote-cache/src/test/java/com/hotels/molten/cache/redis/codec/FlatStringKeyCodecTest.java
+++ b/molten-remote-cache/src/test/java/com/hotels/molten/cache/redis/codec/FlatStringKeyCodecTest.java
@@ -24,7 +24,6 @@ import java.nio.charset.StandardCharsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -39,7 +38,6 @@ public class FlatStringKeyCodecTest {
 
     @BeforeMethod
     public void initContext() {
-        MockitoAnnotations.initMocks(this);
         codec = new FlatStringKeyCodec<>();
     }
 

--- a/molten-remote-cache/src/test/java/com/hotels/molten/cache/redis/metrics/CommandLatencyMetricsCollectorTest.java
+++ b/molten-remote-cache/src/test/java/com/hotels/molten/cache/redis/metrics/CommandLatencyMetricsCollectorTest.java
@@ -28,8 +28,9 @@ import io.lettuce.core.protocol.ProtocolKeyword;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 import com.hotels.molten.core.metrics.MoltenMetrics;
@@ -37,6 +38,7 @@ import com.hotels.molten.core.metrics.MoltenMetrics;
 /**
  * Unit test for {@link CommandLatencyMetricsCollector}.
  */
+@Listeners(MockitoTestNGListener.class)
 public class CommandLatencyMetricsCollectorTest {
     private static final String QUALIFIER = "qualifier";
     private static final String REMOTE_HOST = "remote.host";
@@ -52,7 +54,6 @@ public class CommandLatencyMetricsCollectorTest {
 
     @BeforeMethod
     public void initContext() {
-        MockitoAnnotations.initMocks(this);
         meterRegistry = new SimpleMeterRegistry();
     }
 

--- a/molten-root/pom.xml
+++ b/molten-root/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>com.expediagroup.molten</groupId>
     <artifactId>molten-platform</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../molten-platform/pom.xml</relativePath>
   </parent>
 
   <artifactId>molten-root</artifactId>
-  <version>1.0.1-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <name>Molten - root</name>
   <description>A reactive toolbox for integration</description>
   <packaging>pom</packaging>

--- a/molten-root/pom.xml
+++ b/molten-root/pom.xml
@@ -32,6 +32,7 @@
     <module>../molten-metrics</module>
     <module>../molten-remote-cache</module>
     <module>../molten-test</module>
+    <module>../molten-test-mockito-autoconfigure</module>
   </modules>
 
   <dependencyManagement>

--- a/molten-test-mockito-autoconfigure/pom.xml
+++ b/molten-test-mockito-autoconfigure/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.expediagroup.molten</groupId>
+        <artifactId>molten-root</artifactId>
+        <version>1.0.1-SNAPSHOT</version>
+        <relativePath>../molten-root/pom.xml</relativePath>
+    </parent>
+    <artifactId>molten-test-mockito-autoconfigure</artifactId>
+
+    <name>Molten - test support - mockito autoconfiguration</name>
+    <description>Provides Mockito autoconfiguration for molten test support.</description>
+
+    <properties>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/molten-test-mockito-autoconfigure/pom.xml
+++ b/molten-test-mockito-autoconfigure/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.expediagroup.molten</groupId>
         <artifactId>molten-root</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../molten-root/pom.xml</relativePath>
     </parent>
     <artifactId>molten-test-mockito-autoconfigure</artifactId>

--- a/molten-test-mockito-autoconfigure/readme.md
+++ b/molten-test-mockito-autoconfigure/readme.md
@@ -1,0 +1,39 @@
+#molten-test-mockito-autoconfigure
+
+Provides auto-configured Mockito for testing reactive code.
+Included by [molten-test](../molten-test/readme.md) as a transitive dependency.
+
+## How to disable
+
+If you need to disable this feature because it causes any error or
+there is already a `org.mockito.configuration.MockitoConfiguration` on your test classpath,
+just exclude it from the `molten-test` dependency.
+
+```xml
+  <dependency>
+    <groupId>com.expediagroup.molten</groupId>
+    <artifactId>molten-test</artifactId>
+    <version>${molten.version}</version>
+    <scope>test</scope>
+    <exclusions>
+      <exclusion>
+        <groupId>com.expediagroup.molten</groupId>
+        <artifactId>molten-test-mockito-autoconfigure</artifactId>
+      </exclusion>
+    </exclusions>
+  </dependency>
+```
+
+## How to merge with your custom MockitoConfiguration
+
+If you would keep to use reactive mocks along with your custom configuration,
+just [disable the feature](#how-to-disable) and set up the default answer in your `org.mockito.configuration.MockitoConfiguration`.
+
+```java
+public class MockitoConfiguration extends DefaultMockitoConfiguration {
+    @Override
+    public Answer<Object> getDefaultAnswer() {
+        return new ReactiveAnswer(super.getDefaultAnswer());
+    }
+}
+```

--- a/molten-test-mockito-autoconfigure/src/main/java/org/mockito/configuration/MockitoConfiguration.java
+++ b/molten-test-mockito-autoconfigure/src/main/java/org/mockito/configuration/MockitoConfiguration.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2020 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mockito.configuration;
+
+import org.mockito.exceptions.misusing.MockitoConfigurationException;
+import org.mockito.stubbing.Answer;
+
+/**
+ * Mockito configuration to set {@code com.hotels.molten.test.mockito.ReactiveMockitoConfiguration} as default.
+ * <p>
+ * In order to configure Mockito on your own, just exclude {@code com.expediagroup.molten:molten-test-mockito-autoconfigure} transitive dependency
+ * from your {@code com.expediagroup.molten:molten-test} dependency.
+ */
+public class MockitoConfiguration extends DefaultMockitoConfiguration {
+    private static final String REACTIVE_CONFIGURATION_CLASS_NAME = "com.hotels.molten.test.mockito.ReactiveMockitoConfiguration";
+    private static final IMockitoConfiguration REACTIVE_CONFIGURATION;
+
+    static {
+        Class<?> configClass;
+        try {
+            configClass = Class.forName(REACTIVE_CONFIGURATION_CLASS_NAME);
+        } catch (ClassNotFoundException e) {
+            throw new MockitoConfigurationException("Unable to find " + REACTIVE_CONFIGURATION_CLASS_NAME + " class."
+                + "Is there the correct version of 'com.expediagroup.molten:molten-test' on the classpath?", e);
+        }
+        try {
+            REACTIVE_CONFIGURATION = (IMockitoConfiguration) configClass.getDeclaredConstructor().newInstance();
+        } catch (ClassCastException e) {
+            throw new MockitoConfigurationException("MockitoConfiguration class must implement " + IMockitoConfiguration.class.getName() + " interface.", e);
+        } catch (Exception e) {
+            throw new MockitoConfigurationException("Unable to instantiate " + REACTIVE_CONFIGURATION_CLASS_NAME + " class."
+                + "Is there the correct version of 'com.expediagroup.molten:molten-test' on the classpath?", e);
+        }
+    }
+
+    @Override
+    public Answer<Object> getDefaultAnswer() {
+        return REACTIVE_CONFIGURATION.getDefaultAnswer();
+    }
+
+    @Override
+    public AnnotationEngine getAnnotationEngine() {
+        return REACTIVE_CONFIGURATION.getAnnotationEngine();
+    }
+}

--- a/molten-test/pom.xml
+++ b/molten-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.expediagroup.molten</groupId>
     <artifactId>molten-root</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../molten-root/pom.xml</relativePath>
   </parent>
   <artifactId>molten-test</artifactId>

--- a/molten-test/pom.xml
+++ b/molten-test/pom.xml
@@ -17,7 +17,6 @@
   </properties>
 
   <dependencies>
-    <!-- TODO jupiter optional! dependency -->
     <dependency>
       <groupId>io.projectreactor</groupId>
       <artifactId>reactor-core</artifactId>
@@ -40,6 +39,11 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.expediagroup.molten</groupId>
+      <artifactId>molten-test-mockito-autoconfigure</artifactId>
+      <scope>runtime</scope>
     </dependency>
   </dependencies>
 </project>

--- a/molten-test/pom.xml
+++ b/molten-test/pom.xml
@@ -17,6 +17,7 @@
   </properties>
 
   <dependencies>
+    <!-- TODO jupiter optional! dependency -->
     <dependency>
       <groupId>io.projectreactor</groupId>
       <artifactId>reactor-core</artifactId>

--- a/molten-test/readme.md
+++ b/molten-test/readme.md
@@ -4,18 +4,14 @@ Provides helper classes for testing reactive code.
 
 ## Reactive mocks
 
-To create Mockito mocks over reactive APIs one should use the `@ReactiveMock` annotation.
-This creates a mock with default empty answers for reactive return types and also supports default methods on the interfaces.
+After this module is on the test classpath, reactive Mockito mocks are created over your reactive APIs.
+Reactive mock is a mock with default empty answers for reactive return types.
 
 ```java
-public class SomeTestNGTest {
-    @ReactiveMock
+@ExtendWith(MockitoExtension.class)
+public class SomeJunitJupiterTest {
+    @Mock
     private ReactiveApi reactiveApi;
-    
-    @BeforeMethod
-    public void initContext() {
-        ReactiveMockitoAnnotations.initMocks(this);
-    }
     
     @Test
     public void shouldEmitStubValue() {
@@ -45,6 +41,10 @@ public class SomeTestNGTest {
     }
 }
 ```
+
+This is achieved by configuring the default answer in `org.mockito.configuration.MockitoConfiguration`.
+If you are already configuring Mockito through that class, or just want to turn this feature off,
+see the options on [molten-test-mockito-autoconfigure](../molten-test-mockito-autoconfigure/readme.md).
 
 ## Unstable types
 To test hot publishers with resubscription one can use `com.hotels.molten.test.UnstableMono`.

--- a/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveAnnotationEngine.java
+++ b/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveAnnotationEngine.java
@@ -16,76 +16,61 @@
 
 package com.hotels.molten.test.mockito;
 
-import static org.mockito.internal.exceptions.Reporter.moreThanOneAnnotationNotAllowed;
+import static java.util.stream.Collectors.toSet;
+import static org.mockito.internal.exceptions.Reporter.unsupportedCombinationOfAnnotations;
 import static org.mockito.internal.util.reflection.FieldSetter.setField;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+import java.lang.reflect.Modifier;
+import java.util.Set;
+import java.util.stream.Stream;
 
 import org.mockito.Captor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.exceptions.base.MockitoException;
-import org.mockito.internal.configuration.CaptorAnnotationProcessor;
 import org.mockito.internal.configuration.FieldAnnotationProcessor;
-import org.mockito.internal.configuration.MockAnnotationProcessor;
-import org.mockito.plugins.AnnotationEngine;
 
 /**
- * Initializes fields annotated with &#64;{@link org.mockito.Mock} or &#64;{@link org.mockito.Captor}.
+ * Initializes fields annotated with &#64;{@link ReactiveMock}.
  * <p>
  * The {@link #process(Class, Object)} method implementation <strong>does not</strong> process super classes!
  *
- * @see org.mockito.MockitoAnnotations
- * @see org.mockito.internal.configuration.IndependentAnnotationEngine
+ * @see ReactiveInjectingAnnotationEngine
+ * @see org.mockito.internal.configuration.InjectingAnnotationEngine
  */
-@SuppressWarnings("unchecked")
-public class ReactiveAnnotationEngine implements AnnotationEngine {
-    private final Map<Class<? extends Annotation>, FieldAnnotationProcessor<?>> annotationProcessorMap = new HashMap<Class<? extends Annotation>, FieldAnnotationProcessor<?>>();
+public class ReactiveAnnotationEngine {
+    private final FieldAnnotationProcessor<ReactiveMock> reactiveMockProcessor = new ReactiveMockAnnotationProcessor();
 
-    public ReactiveAnnotationEngine() {
-        registerAnnotationProcessor(Mock.class, new MockAnnotationProcessor());
-        registerAnnotationProcessor(Captor.class, new CaptorAnnotationProcessor());
-        registerAnnotationProcessor(ReactiveMock.class, new ReactiveMockAnnotationProcessor());
-    }
-
-    @Override
-    public void process(Class<?> clazz, Object testInstance) {
-        Field[] fields = clazz.getDeclaredFields();
-        for (Field field : fields) {
-            boolean alreadyAssigned = false;
-            for (Annotation annotation : field.getAnnotations()) {
-                Object mock = createMockFor(annotation, field);
-                if (mock != null) {
-                    throwIfAlreadyAssigned(field, alreadyAssigned);
-                    alreadyAssigned = true;
-                    try {
-                        setField(testInstance, field, mock);
-                    } catch (Exception e) {
-                        throw new MockitoException("Problems setting field " + field.getName() + " annotated with " + annotation, e);
-                    }
+    // not extends AnnotationEngine so can return the created mocks
+    public Set<Object> process(Class<?> clazz, Object testInstance) {
+        return Stream.of(clazz.getDeclaredFields())
+            .filter(field -> field.isAnnotationPresent(ReactiveMock.class))
+            .peek(field -> assertNoIncompatibleAnnotations(ReactiveMock.class, field, Mock.class, Spy.class, Captor.class, InjectMocks.class))
+            .map(field -> {
+                Object reactiveMock = reactiveMockProcessor.process(field.getAnnotation(ReactiveMock.class), field);
+                try {
+                    setField(Modifier.isStatic(field.getModifiers()) ? null : testInstance, field, reactiveMock);
+                } catch (Exception e) {
+                    throw new MockitoException("Problems setting field " + field.getName() + " annotated with " + ReactiveMock.class, e);
                 }
+                return reactiveMock;
+            })
+            .collect(toSet());
+    }
+
+    @SafeVarargs
+    private static void assertNoIncompatibleAnnotations(
+        Class<? extends Annotation> annotation,
+        Field field,
+        Class<? extends Annotation>... undesiredAnnotations) {
+        for (Class<? extends Annotation> u : undesiredAnnotations) {
+            if (field.isAnnotationPresent(u)) {
+                throw unsupportedCombinationOfAnnotations(
+                    annotation.getSimpleName(), u.getSimpleName());
             }
-        }
-    }
-
-    private <A extends Annotation> void registerAnnotationProcessor(Class<A> annotationClass, FieldAnnotationProcessor<A> fieldAnnotationProcessor) {
-        annotationProcessorMap.put(annotationClass, fieldAnnotationProcessor);
-    }
-
-    private Object createMockFor(Annotation annotation, Field field) {
-        return forAnnotation(annotation).process(annotation, field);
-    }
-
-    private <A extends Annotation> FieldAnnotationProcessor<A> forAnnotation(A annotation) {
-        return Optional.ofNullable((FieldAnnotationProcessor<A>) annotationProcessorMap.get(annotation.annotationType())).orElse((annotation1, field) -> null);
-    }
-
-    private void throwIfAlreadyAssigned(Field field, boolean alreadyAssigned) {
-        if (alreadyAssigned) {
-            throw moreThanOneAnnotationNotAllowed(field.getName());
         }
     }
 }

--- a/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveAnnotationEngine.java
+++ b/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveAnnotationEngine.java
@@ -18,7 +18,6 @@ package com.hotels.molten.test.mockito;
 
 import static java.util.stream.Collectors.toSet;
 import static org.mockito.internal.exceptions.Reporter.unsupportedCombinationOfAnnotations;
-import static org.mockito.internal.util.reflection.FieldSetter.setField;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
@@ -32,6 +31,8 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.configuration.FieldAnnotationProcessor;
+import org.mockito.internal.configuration.plugins.Plugins;
+import org.mockito.plugins.MemberAccessor;
 
 /**
  * Initializes fields annotated with &#64;{@link ReactiveMock}.
@@ -51,8 +52,9 @@ public class ReactiveAnnotationEngine {
             .peek(field -> assertNoIncompatibleAnnotations(ReactiveMock.class, field, Mock.class, Spy.class, Captor.class, InjectMocks.class))
             .map(field -> {
                 Object reactiveMock = reactiveMockProcessor.process(field.getAnnotation(ReactiveMock.class), field);
+                MemberAccessor accessor = Plugins.getMemberAccessor();
                 try {
-                    setField(Modifier.isStatic(field.getModifiers()) ? null : testInstance, field, reactiveMock);
+                    accessor.set(field, Modifier.isStatic(field.getModifiers()) ? null : testInstance, reactiveMock);
                 } catch (Exception e) {
                     throw new MockitoException("Problems setting field " + field.getName() + " annotated with " + ReactiveMock.class, e);
                 }

--- a/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveAnnotationEngine.java
+++ b/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveAnnotationEngine.java
@@ -36,7 +36,6 @@ import org.mockito.plugins.AnnotationEngine;
 /**
  * Initializes fields annotated with &#64;{@link org.mockito.Mock} or &#64;{@link org.mockito.Captor}.
  * <p>
- * <p>
  * The {@link #process(Class, Object)} method implementation <strong>does not</strong> process super classes!
  *
  * @see org.mockito.MockitoAnnotations

--- a/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveAnnotationEngine.java
+++ b/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveAnnotationEngine.java
@@ -41,7 +41,9 @@ import org.mockito.plugins.MemberAccessor;
  *
  * @see ReactiveInjectingAnnotationEngine
  * @see org.mockito.internal.configuration.InjectingAnnotationEngine
+ * @deprecated will be removed along with {@link ReactiveMock}, see details there
  */
+@Deprecated
 public class ReactiveAnnotationEngine {
     private final FieldAnnotationProcessor<ReactiveMock> reactiveMockProcessor = new ReactiveMockAnnotationProcessor();
 

--- a/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveAnswer.java
+++ b/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveAnswer.java
@@ -19,19 +19,29 @@ package com.hotels.molten.test.mockito;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.withSettings;
 
-import org.mockito.internal.stubbing.defaultanswers.ReturnsEmptyValues;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 /**
  * Mockito default return values for Reactor reactive types.
  */
-public class ReactiveAnswer extends ReturnsEmptyValues {
+@RequiredArgsConstructor
+public class ReactiveAnswer implements Answer<Object> {
+    @NonNull
+    private final Answer<Object> delegateAnswer;
+
+    public ReactiveAnswer() {
+        delegateAnswer = Mockito.RETURNS_DEFAULTS;
+    }
 
     @Override
-    public Object answer(InvocationOnMock invocation) {
-        Object answer = super.answer(invocation);
+    public Object answer(InvocationOnMock invocation) throws Throwable {
+        Object answer = delegateAnswer.answer(invocation);
         if (answer == null) {
             Class<?> returnType = invocation.getMethod().getReturnType();
             if (returnType == Mono.class) {
@@ -51,7 +61,7 @@ public class ReactiveAnswer extends ReturnsEmptyValues {
      * @param <T>         the actual type of the mock
      * @return the mock
      */
-    public static <T> T reactiveMock(Class<T> classToMock) {
+    public static <T> T reactiveMock(Class<T> classToMock) { //TODO what to do with me?
         return mock(classToMock,
             withSettings().defaultAnswer(invocation -> invocation.getMethod().isDefault() ? invocation.callRealMethod() : new ReactiveAnswer().answer(invocation)));
     }

--- a/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveAnswer.java
+++ b/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveAnswer.java
@@ -22,7 +22,6 @@ import java.util.Map;
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import reactor.core.publisher.Flux;
@@ -39,10 +38,6 @@ public class ReactiveAnswer implements Answer<Object> {
     );
     @NonNull
     private final Answer<Object> delegateAnswer;
-
-    public ReactiveAnswer() {
-        delegateAnswer = Mockito.RETURNS_DEFAULTS;
-    }
 
     @Override
     public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -61,7 +56,7 @@ public class ReactiveAnswer implements Answer<Object> {
      * @param classToMock the type to create mock for
      * @param <T>         the actual type of the mock
      * @return the mock
-     * @deprecated will be removed, use {@link Mockito#mock(Class)} instead
+     * @deprecated will be removed, use {@link org.mockito.Mockito#mock(Class)} instead
      */
     @Deprecated
     public static <T> T reactiveMock(Class<T> classToMock) {

--- a/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveInjectingAnnotationEngine.java
+++ b/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveInjectingAnnotationEngine.java
@@ -25,7 +25,10 @@ import org.mockito.internal.configuration.InjectingAnnotationEngine;
  * Entry point {@link org.mockito.plugins.AnnotationEngine} of reactive mocking.
  * <p>
  * Extends {@link InjectingAnnotationEngine} behaviour with {@link ReactiveAnnotationEngine}.
+ *
+ * @deprecated will be removed along with {@link ReactiveMock}, see details there
  */
+@Deprecated
 public class ReactiveInjectingAnnotationEngine extends InjectingAnnotationEngine {
     private final ReactiveAnnotationEngine reactiveAnnotationEngine = new ReactiveAnnotationEngine();
 

--- a/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveInjectingAnnotationEngine.java
+++ b/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveInjectingAnnotationEngine.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hotels.molten.test.mockito;
+
+import java.lang.reflect.Field;
+import java.util.Set;
+
+import org.mockito.internal.configuration.InjectingAnnotationEngine;
+
+/**
+ * Entry point {@link org.mockito.plugins.AnnotationEngine} of reactive mocking.
+ * <p>
+ * Extends {@link InjectingAnnotationEngine} behaviour with {@link ReactiveAnnotationEngine}.
+ */
+public class ReactiveInjectingAnnotationEngine extends InjectingAnnotationEngine {
+    private final ReactiveAnnotationEngine reactiveAnnotationEngine = new ReactiveAnnotationEngine();
+
+    @Override
+    protected void onInjection(Object testInstance, Class<?> clazz, Set<Field> mockDependentFields, Set<Object> mocks) {
+        mocks.addAll(reactiveAnnotationEngine.process(clazz, testInstance));
+    }
+}

--- a/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveMock.java
+++ b/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveMock.java
@@ -23,40 +23,27 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import org.mockito.Answers;
-
 /**
  * Marks a field as a reactive mock.
  * <p>
- * <strong><code>ReactiveMockitoAnnotations.initMocks(this)</code></strong> method has to be called to initialize annotated objects.
+ * <strong>{@link ReactiveMockitoAnnotations#initMocks(Object)}</strong> method has to be called to initialize annotated objects.
  *
  * @see org.mockito.Mock
  * @see org.mockito.Spy
  * @see org.mockito.InjectMocks
  * @see org.mockito.MockitoAnnotations#openMocks(Object)
  * @see org.mockito.junit.MockitoJUnitRunner
+ * @deprecated Please use the usual way to create your reactive mocks, like annotation with {@link org.mockito.Mock} or creating with {@link org.mockito.Mockito#mock(Class)}.
+ * <p>
+ * To skip stubbing non-abstract methods on a mock, please configure it's default answer with {@link org.mockito.Answers#CALLS_REAL_METHODS}.
+ * <p>
+ * To skip stubbing a specific non-abstract method, use the usual mocking mechanisms, like {@code when(mock.someMethod()).thenCallRealMethod()}.
  */
 @Target(FIELD)
 @Retention(RUNTIME)
 @Documented
+@Deprecated
 public @interface ReactiveMock {
-
-    /**
-     * Sets the default answer for methods with <b>non-reactive</b> return types, except the interface default methods.
-     * <p>
-     * For reactive return types, default reactive answers are applied regardless of this.
-     *
-     * @see ReactiveAnswer
-     * @see org.mockito.MockSettings#defaultAnswer
-     */
-    Answers answer() default Answers.RETURNS_DEFAULTS;
-
-    /**
-     * Enables mocking of default methods of interfaces.
-     *
-     * @see org.mockito.MockSettings#defaultAnswer
-     */
-    boolean mockDefaultMethods() default false;
 
     /**
      * Mock will have custom name (shown in verification errors), see {@link org.mockito.MockSettings#name(String)}.

--- a/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveMock.java
+++ b/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveMock.java
@@ -28,6 +28,7 @@ import java.lang.annotation.Target;
  * <p>
  * <strong><code>ReactiveMockitoAnnotations.initMocks(this)</code></strong> method has to be called to initialize annotated objects.
  *
+ * @see org.mockito.Mock
  * @see org.mockito.Spy
  * @see org.mockito.InjectMocks
  * @see ReactiveMockitoAnnotations#initMocks(Object)
@@ -37,6 +38,9 @@ import java.lang.annotation.Target;
 @Retention(RUNTIME)
 @Documented
 public @interface ReactiveMock {
+    // TODO support answers
+    // TODO support lenient
+    // TODO mock interface default methods
     String name() default "";
 
     Class<?>[] extraInterfaces() default {};

--- a/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveMock.java
+++ b/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveMock.java
@@ -23,6 +23,8 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import org.mockito.Answers;
+
 /**
  * Marks a field as a reactive mock.
  * <p>
@@ -31,21 +33,53 @@ import java.lang.annotation.Target;
  * @see org.mockito.Mock
  * @see org.mockito.Spy
  * @see org.mockito.InjectMocks
- * @see ReactiveMockitoAnnotations#initMocks(Object)
+ * @see org.mockito.MockitoAnnotations#openMocks(Object)
  * @see org.mockito.junit.MockitoJUnitRunner
  */
 @Target(FIELD)
 @Retention(RUNTIME)
 @Documented
 public @interface ReactiveMock {
-    // TODO support answers
-    // TODO support lenient
-    // TODO mock interface default methods
+
+    /**
+     * Sets the default answer for methods with <b>non-reactive</b> return types, except the interface default methods.
+     * <p>
+     * For reactive return types, default reactive answers are applied regardless of this.
+     *
+     * @see ReactiveAnswer
+     * @see org.mockito.MockSettings#defaultAnswer
+     */
+    Answers answer() default Answers.RETURNS_DEFAULTS;
+
+    /**
+     * Enables mocking of default methods of interfaces.
+     *
+     * @see org.mockito.MockSettings#defaultAnswer
+     */
+    boolean mockDefaultMethods() default false;
+
+    /**
+     * Mock will have custom name (shown in verification errors), see {@link org.mockito.MockSettings#name(String)}.
+     */
     String name() default "";
 
+    /**
+     * Mock will have extra interfaces, see {@link org.mockito.MockSettings#extraInterfaces(Class[])}.
+     */
     Class<?>[] extraInterfaces() default {};
 
+    /**
+     * Mock will be 'stubOnly', see {@link org.mockito.MockSettings#stubOnly()}.
+     */
     boolean stubOnly() default false;
 
+    /**
+     * Mock will be serializable, see {@link org.mockito.MockSettings#serializable()}.
+     */
     boolean serializable() default false;
+
+    /**
+     * Mock will be lenient, see {@link org.mockito.MockSettings#lenient()}.
+     */
+    boolean lenient() default false;
 }

--- a/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveMockAnnotationProcessor.java
+++ b/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveMockAnnotationProcessor.java
@@ -20,17 +20,20 @@ import static org.mockito.Mockito.mock;
 
 import java.lang.reflect.Field;
 
+import org.mockito.Answers;
 import org.mockito.MockSettings;
 import org.mockito.Mockito;
 import org.mockito.internal.configuration.FieldAnnotationProcessor;
-import org.mockito.stubbing.Answer;
 
 /**
  * Instantiates a mock on a field annotated by {@link ReactiveMock}.
+ *
+ * @deprecated will be removed along with {@link ReactiveMock}, see details there
  */
+@Deprecated
 public class ReactiveMockAnnotationProcessor implements FieldAnnotationProcessor<ReactiveMock> {
     public Object process(ReactiveMock annotation, Field field) {
-        return mock(field.getType(), createSettings(annotation, field.getName())); // TODO add scoped mock support
+        return mock(field.getType(), createSettings(annotation, field.getName()));
     }
 
     private MockSettings createSettings(ReactiveMock annotation, String defaultName) {
@@ -52,13 +55,7 @@ public class ReactiveMockAnnotationProcessor implements FieldAnnotationProcessor
         if (annotation.lenient()) {
             mockSettings.lenient();
         }
-        return mockSettings.defaultAnswer(createAnswer(annotation));
-    }
-
-    private Answer<Object> createAnswer(ReactiveMock annotation) {
-        return annotation.mockDefaultMethods()
-            ? new ReactiveAnswer(annotation.answer())
-            : new SkippedDefaultMethodAnswer(new ReactiveAnswer(annotation.answer()));
+        return mockSettings.defaultAnswer(new SkippedDefaultMethodAnswer(Answers.RETURNS_DEFAULTS));
     }
 }
 

--- a/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveMockitoAnnotations.java
+++ b/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveMockitoAnnotations.java
@@ -27,6 +27,8 @@ public class ReactiveMockitoAnnotations {
      * &#064;{@link org.mockito.Mock}, &#064;{@link org.mockito.Spy}, &#064;{@link org.mockito.Captor}, &#064;{@link org.mockito.InjectMocks}
      * <p>
      * See examples in javadoc for {@link org.mockito.MockitoAnnotations} class.
+     *
+     * @param testClass the test class to initialize
      */
     public static void initMocks(Object testClass) {
         if (testClass == null) {

--- a/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveMockitoAnnotations.java
+++ b/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveMockitoAnnotations.java
@@ -16,11 +16,14 @@
 
 package com.hotels.molten.test.mockito;
 
-import org.mockito.exceptions.base.MockitoException;
+import org.mockito.MockitoAnnotations;
 
 /**
  * Initializes regular Mockito mocks and reactive mocks.
+ *
+ * @deprecated Use {@link org.mockito.MockitoAnnotations#openMocks(Object)} instead, or the {@code MockitoExtension} if having JUnit Jupiter tests.
  */
+@Deprecated
 public class ReactiveMockitoAnnotations {
     /**
      * Initializes objects annotated with Mockito annotations for given testClass:
@@ -29,11 +32,10 @@ public class ReactiveMockitoAnnotations {
      * See examples in javadoc for {@link org.mockito.MockitoAnnotations} class.
      *
      * @param testClass the test class to initialize
+     * @deprecated Use {@link org.mockito.MockitoAnnotations#openMocks(Object)} instead, or the {@code MockitoExtension} if having JUnit Jupiter tests.
      */
+    @Deprecated
     public static void initMocks(Object testClass) {
-        if (testClass == null) {
-            throw new MockitoException("testClass cannot be null. For info how to use @Mock annotations see examples in javadoc for MockitoAnnotations class");
-        }
-        new ReactiveAnnotationEngine().process(testClass.getClass(), testClass);
+        MockitoAnnotations.initMocks(testClass);
     }
 }

--- a/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveMockitoAnnotations.java
+++ b/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveMockitoAnnotations.java
@@ -21,6 +21,7 @@ import org.mockito.MockitoAnnotations;
 /**
  * Initializes regular Mockito mocks and reactive mocks.
  *
+ * @see org.mockito.MockitoAnnotations
  * @deprecated Use {@link org.mockito.MockitoAnnotations#openMocks(Object)} instead, or the {@code MockitoExtension} if having JUnit Jupiter tests.
  */
 @Deprecated

--- a/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveMockitoConfiguration.java
+++ b/molten-test/src/main/java/com/hotels/molten/test/mockito/ReactiveMockitoConfiguration.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hotels.molten.test.mockito;
+
+import org.mockito.configuration.AnnotationEngine;
+import org.mockito.configuration.DefaultMockitoConfiguration;
+import org.mockito.internal.configuration.plugins.Plugins;
+import org.mockito.stubbing.Answer;
+
+/**
+ * Mockito configuration to set the default answer. To configure mockito further, well you just can't do that right now.
+ */
+public class ReactiveMockitoConfiguration extends DefaultMockitoConfiguration {
+    @Override
+    public Answer<Object> getDefaultAnswer() {
+        return new ReactiveAnswer(super.getDefaultAnswer());
+    }
+
+    /**
+     * Legacy way to provide annotation engine from {@link Plugins#getAnnotationEngine()}, which is the default behaviour.
+     *
+     * @see org.mockito.configuration.IMockitoConfiguration#getAnnotationEngine()
+     * @deprecated will be removed once removed from {@link org.mockito.configuration.IMockitoConfiguration} by the Mockito team
+     */
+    @Deprecated
+    @Override
+    public AnnotationEngine getAnnotationEngine() {
+        return Plugins.getAnnotationEngine()::process;
+    }
+}

--- a/molten-test/src/main/java/com/hotels/molten/test/mockito/SkippedDefaultMethodAnswer.java
+++ b/molten-test/src/main/java/com/hotels/molten/test/mockito/SkippedDefaultMethodAnswer.java
@@ -27,7 +27,11 @@ import org.mockito.stubbing.Answer;
  * Other invocations are delegated to the given {@link Answer}.
  *
  * @see Answers
+ * @deprecated To keep non-abstract methods on a mock, please configure it's default answer with {@link Answers#CALLS_REAL_METHODS} instead.
+ * <p>
+ * To keep implementation on specific method, use the usual mocking mechanism. Example: {@code when(mock.someMethod()).thenAnswer(CALLS_REAL_METHODS)}.
  */
+@Deprecated
 @RequiredArgsConstructor
 public class SkippedDefaultMethodAnswer implements Answer<Object> {
     @NonNull

--- a/molten-test/src/main/java/com/hotels/molten/test/mockito/SkippedDefaultMethodAnswer.java
+++ b/molten-test/src/main/java/com/hotels/molten/test/mockito/SkippedDefaultMethodAnswer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hotels.molten.test.mockito;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.mockito.Answers;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+/**
+ * Mockito {@link Answer} to honor default methods invoking them as is.
+ * Other invocations are delegated to the given {@link Answer}.
+ *
+ * @see Answers
+ */
+@RequiredArgsConstructor
+public class SkippedDefaultMethodAnswer implements Answer<Object> {
+    @NonNull
+    private final Answer<Object> delegate;
+
+    @Override
+    public Object answer(InvocationOnMock invocation) throws Throwable {
+        return invocation.getMethod().isDefault()
+            ? Answers.CALLS_REAL_METHODS.answer(invocation)
+            : delegate.answer(invocation);
+    }
+}

--- a/molten-test/src/main/resources/mockito-extensions/org.mockito.plugins.AnnotationEngine
+++ b/molten-test/src/main/resources/mockito-extensions/org.mockito.plugins.AnnotationEngine
@@ -1,0 +1,1 @@
+com.hotels.molten.test.mockito.ReactiveInjectingAnnotationEngine

--- a/molten-test/src/test/java/com/hotels/molten/test/JUnitJupiterTest.java
+++ b/molten-test/src/test/java/com/hotels/molten/test/JUnitJupiterTest.java
@@ -20,10 +20,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 
 @Slf4j
-public class JunitTest {
+public class JUnitJupiterTest {
     @Test
     public void should() {
-        LOG.info("JUnit tests are running.");
+        LOG.info("JUnit 5 tests are running.");
     }
 
 }

--- a/molten-test/src/test/java/com/hotels/molten/test/mockito/ReactiveApi.java
+++ b/molten-test/src/test/java/com/hotels/molten/test/mockito/ReactiveApi.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2020 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hotels.molten.test.mockito;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Test object which has methods returning with reactive types.
+ */
+interface ReactiveApi {
+    Flux<String> getAll(int id);
+
+    default Mono<String> getFirst(int id) {
+        return getAll(id).take(1).single();
+    }
+}

--- a/molten-test/src/test/java/com/hotels/molten/test/mockito/ReactiveApi.java
+++ b/molten-test/src/test/java/com/hotels/molten/test/mockito/ReactiveApi.java
@@ -28,4 +28,6 @@ interface ReactiveApi {
     default Mono<String> getFirst(int id) {
         return getAll(id).take(1).single();
     }
+
+    ReactiveApi self();
 }

--- a/molten-test/src/test/java/com/hotels/molten/test/mockito/ReactiveMockByInitMocksTest.java
+++ b/molten-test/src/test/java/com/hotels/molten/test/mockito/ReactiveMockByInitMocksTest.java
@@ -16,59 +16,78 @@
 
 package com.hotels.molten.test.mockito;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
-import static org.mockito.Mockito.when;
-
 import java.util.function.Function;
+import java.util.stream.Stream;
 
+import org.mockito.Answers;
+import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import reactor.core.publisher.Flux;
-import reactor.test.StepVerifier;
 
 /**
  * Unit test for {@link ReactiveMock} initiated by {@link MockitoAnnotations#initMocks}.
  */
 public class ReactiveMockByInitMocksTest {
-    private static final int ID = 1;
-    private static final String VALUE_A = "a";
-    private static final String VALUE_B = "b";
     @ReactiveMock
-    private ReactiveApi reactiveApi;
-    @ReactiveMock(serializable = true, stubOnly = true, extraInterfaces = Function.class, name = "custom name")
-    private ReactiveApi serializableStubOnlyReactiveApi;
+    private ReactiveApi legacyReactiveMock;
+    @ReactiveMock(serializable = true, stubOnly = true, extraInterfaces = Function.class, name = "custom legacy mock")
+    private ReactiveApi customLegacyReactiveMock;
+    @Mock
+    private ReactiveApi reactiveMock;
+    @Mock(answer = Answers.CALLS_REAL_METHODS, name = "custom mock")
+    private ReactiveApi callsRealReactiveMock;
 
     @BeforeMethod
     public void initContext() {
         MockitoAnnotations.initMocks(this);
     }
 
-    @Test
-    public void shouldEmitStubValue() {
-        when(reactiveApi.getAll(ID)).thenReturn(Flux.just(VALUE_A, VALUE_B));
-
-        StepVerifier.create(reactiveApi.getAll(ID)).expectSubscription().expectNext(VALUE_A, VALUE_B).expectComplete().verify();
+    @DataProvider
+    public static Object[][] mocks() {
+        return Stream.<MockHolder>of(
+            test -> test.legacyReactiveMock,
+            test -> test.customLegacyReactiveMock,
+            test -> test.reactiveMock,
+            test -> test.callsRealReactiveMock
+        )
+            .map(mock -> new Object[]{mock})
+            .toArray(Object[][]::new);
     }
 
-    @Test
-    public void shouldEmitEmptyByDefault() {
-        StepVerifier.create(reactiveApi.getAll(ID)).expectSubscription().expectComplete().verify();
+    @DataProvider
+    public static Object[][] callRealMocks() {
+        return Stream.<MockHolder>of(
+            test -> test.legacyReactiveMock,
+            test -> test.customLegacyReactiveMock,
+            test -> test.callsRealReactiveMock
+        )
+            .map(mock -> new Object[]{mock})
+            .toArray(Object[][]::new);
     }
 
-    @Test
-    public void shouldSupportDefaultMethod() {
-        when(reactiveApi.getAll(ID)).thenReturn(Flux.just(VALUE_A, VALUE_B));
-
-        StepVerifier.create(reactiveApi.getFirst(ID)).expectSubscription().expectNext(VALUE_A).expectComplete().verify();
+    @Test(dataProvider = "mocks")
+    public void shouldEmitStubValue(MockHolder mockHolder) {
+        ReactiveMockTestCases.shouldEmitStubValue(mockHolder.extract(this));
     }
 
-    @Test
-    public void shouldSupportMockitoAnnotationProperties() {
-        assertThat(serializableStubOnlyReactiveApi, is(not(nullValue())));
+    @Test(dataProvider = "mocks")
+    public void shouldEmitEmptyByDefault(MockHolder mockHolder) {
+        ReactiveMockTestCases.shouldEmitEmptyByDefault(mockHolder.extract(this));
     }
 
+    @Test(dataProvider = "callRealMocks")
+    public void shouldSupportDefaultMethod(MockHolder mockHolder) {
+        ReactiveMockTestCases.shouldSupportDefaultMethod(mockHolder.extract(this));
+    }
+
+    @Test(dataProvider = "mocks")
+    public void shouldSupportMockitoAnnotationProperties(MockHolder mockHolder) {
+        ReactiveMockTestCases.shouldSupportMockitoAnnotationProperties(mockHolder.extract(this));
+    }
+
+    private interface MockHolder {
+        ReactiveApi extract(ReactiveMockByInitMocksTest test);
+    }
 }

--- a/molten-test/src/test/java/com/hotels/molten/test/mockito/ReactiveMockByInitMocksTest.java
+++ b/molten-test/src/test/java/com/hotels/molten/test/mockito/ReactiveMockByInitMocksTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2020 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hotels.molten.test.mockito;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.when;
+
+import java.util.function.Function;
+
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+/**
+ * Unit test for {@link ReactiveMock} initiated by {@link MockitoAnnotations#initMocks}.
+ */
+public class ReactiveMockByInitMocksTest {
+    private static final int ID = 1;
+    private static final String VALUE_A = "a";
+    private static final String VALUE_B = "b";
+    @ReactiveMock
+    private ReactiveApi reactiveApi;
+    @ReactiveMock(serializable = true, stubOnly = true, extraInterfaces = Function.class, name = "custom name")
+    private ReactiveApi serializableStubOnlyReactiveApi;
+
+    @BeforeMethod
+    public void initContext() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void shouldEmitStubValue() {
+        when(reactiveApi.getAll(ID)).thenReturn(Flux.just(VALUE_A, VALUE_B));
+
+        StepVerifier.create(reactiveApi.getAll(ID)).expectSubscription().expectNext(VALUE_A, VALUE_B).expectComplete().verify();
+    }
+
+    @Test
+    public void shouldEmitEmptyByDefault() {
+        StepVerifier.create(reactiveApi.getAll(ID)).expectSubscription().expectComplete().verify();
+    }
+
+    @Test
+    public void shouldSupportDefaultMethod() {
+        when(reactiveApi.getAll(ID)).thenReturn(Flux.just(VALUE_A, VALUE_B));
+
+        StepVerifier.create(reactiveApi.getFirst(ID)).expectSubscription().expectNext(VALUE_A).expectComplete().verify();
+    }
+
+    @Test
+    public void shouldSupportMockitoAnnotationProperties() {
+        assertThat(serializableStubOnlyReactiveApi, is(not(nullValue())));
+    }
+
+}

--- a/molten-test/src/test/java/com/hotels/molten/test/mockito/ReactiveMockByJUnitExtensionTest.java
+++ b/molten-test/src/test/java/com/hotels/molten/test/mockito/ReactiveMockByJUnitExtensionTest.java
@@ -20,12 +20,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
@@ -38,6 +41,8 @@ public class ReactiveMockByJUnitExtensionTest {
     // TODO reactive mock parameter
     // TODO inject reactive mock should work
     // TODO already a mock?
+    // TODO support answers
+    // TODO support lenient
     private static final int ID = 1;
     private static final String VALUE_A = "a";
     private static final String VALUE_B = "b";
@@ -45,6 +50,8 @@ public class ReactiveMockByJUnitExtensionTest {
     private ReactiveApi reactiveApi;
     @ReactiveMock(serializable = true, stubOnly = true, extraInterfaces = Function.class, name = "custom name")
     private ReactiveApi serializableStubOnlyReactiveApi;
+    @ReactiveMock(answer = Answers.RETURNS_DEEP_STUBS)
+    private ReactiveApi deepReactiveApi;
 
     @Test
     public void shouldEmitStubValue() {
@@ -68,5 +75,16 @@ public class ReactiveMockByJUnitExtensionTest {
     @Test
     public void shouldSupportMockitoAnnotationProperties() {
         assertThat(serializableStubOnlyReactiveApi, is(not(nullValue())));
+    }
+
+    @Test
+    public void shouldSupportCustomAnswer() throws Exception {
+        when(deepReactiveApi.self().self()).thenReturn(deepReactiveApi);
+
+        assertThat(deepReactiveApi.self().self(), sameInstance(deepReactiveApi));
+        assertThat(deepReactiveApi.self().self().getAll(ID), is(not(nullValue())));
+
+        StepVerifier.create(deepReactiveApi.getAll(ID)).expectSubscription().expectComplete().verify(Duration.ofSeconds(2L));
+        StepVerifier.create(deepReactiveApi.getAll(ID)).expectSubscription().expectComplete().verify(Duration.ofSeconds(2L));
     }
 }

--- a/molten-test/src/test/java/com/hotels/molten/test/mockito/ReactiveMockByJUnitExtensionTest.java
+++ b/molten-test/src/test/java/com/hotels/molten/test/mockito/ReactiveMockByJUnitExtensionTest.java
@@ -20,15 +20,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.Mockito.when;
 
-import java.time.Duration;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Answers;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
@@ -50,8 +47,6 @@ public class ReactiveMockByJUnitExtensionTest {
     private ReactiveApi reactiveApi;
     @ReactiveMock(serializable = true, stubOnly = true, extraInterfaces = Function.class, name = "custom name")
     private ReactiveApi serializableStubOnlyReactiveApi;
-    @ReactiveMock(answer = Answers.RETURNS_DEEP_STUBS)
-    private ReactiveApi deepReactiveApi;
 
     @Test
     public void shouldEmitStubValue() {
@@ -75,16 +70,5 @@ public class ReactiveMockByJUnitExtensionTest {
     @Test
     public void shouldSupportMockitoAnnotationProperties() {
         assertThat(serializableStubOnlyReactiveApi, is(not(nullValue())));
-    }
-
-    @Test
-    public void shouldSupportCustomAnswer() throws Exception {
-        when(deepReactiveApi.self().self()).thenReturn(deepReactiveApi);
-
-        assertThat(deepReactiveApi.self().self(), sameInstance(deepReactiveApi));
-        assertThat(deepReactiveApi.self().self().getAll(ID), is(not(nullValue())));
-
-        StepVerifier.create(deepReactiveApi.getAll(ID)).expectSubscription().expectComplete().verify(Duration.ofSeconds(2L));
-        StepVerifier.create(deepReactiveApi.getAll(ID)).expectSubscription().expectComplete().verify(Duration.ofSeconds(2L));
     }
 }

--- a/molten-test/src/test/java/com/hotels/molten/test/mockito/ReactiveMockByJUnitExtensionTest.java
+++ b/molten-test/src/test/java/com/hotels/molten/test/mockito/ReactiveMockByJUnitExtensionTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2020 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hotels.molten.test.mockito;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.when;
+
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+/**
+ * Unit test for {@link ReactiveMock} initiated by {@link MockitoExtension}.
+ */
+@ExtendWith(MockitoExtension.class)
+public class ReactiveMockByJUnitExtensionTest {
+    // TODO reactive mock parameter
+    // TODO inject reactive mock should work
+    // TODO already a mock?
+    private static final int ID = 1;
+    private static final String VALUE_A = "a";
+    private static final String VALUE_B = "b";
+    @ReactiveMock
+    private ReactiveApi reactiveApi;
+    @ReactiveMock(serializable = true, stubOnly = true, extraInterfaces = Function.class, name = "custom name")
+    private ReactiveApi serializableStubOnlyReactiveApi;
+
+    @Test
+    public void shouldEmitStubValue() {
+        when(reactiveApi.getAll(ID)).thenReturn(Flux.just(VALUE_A, VALUE_B));
+
+        StepVerifier.create(reactiveApi.getAll(ID)).expectSubscription().expectNext(VALUE_A, VALUE_B).expectComplete().verify();
+    }
+
+    @Test
+    public void shouldEmitEmptyByDefault() {
+        StepVerifier.create(reactiveApi.getAll(ID)).expectSubscription().expectComplete().verify();
+    }
+
+    @Test
+    public void shouldSupportDefaultMethod() {
+        when(reactiveApi.getAll(ID)).thenReturn(Flux.just(VALUE_A, VALUE_B));
+
+        StepVerifier.create(reactiveApi.getFirst(ID)).expectSubscription().expectNext(VALUE_A).expectComplete().verify();
+    }
+
+    @Test
+    public void shouldSupportMockitoAnnotationProperties() {
+        assertThat(serializableStubOnlyReactiveApi, is(not(nullValue())));
+    }
+}

--- a/molten-test/src/test/java/com/hotels/molten/test/mockito/ReactiveMockByOpenMocksTest.java
+++ b/molten-test/src/test/java/com/hotels/molten/test/mockito/ReactiveMockByOpenMocksTest.java
@@ -24,19 +24,21 @@ import static org.mockito.Mockito.when;
 
 import java.util.function.Function;
 
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 /**
- * Unit test for {@link ReactiveMock}.
+ * Unit test for {@link ReactiveMock} initiated by {@link MockitoAnnotations#openMocks}.
  */
-public class ReactiveMockTest {
+public class ReactiveMockByOpenMocksTest {
     private static final int ID = 1;
     private static final String VALUE_A = "a";
     private static final String VALUE_B = "b";
+    private AutoCloseable mocks;
     @ReactiveMock
     private ReactiveApi reactiveApi;
     @ReactiveMock(serializable = true, stubOnly = true, extraInterfaces = Function.class, name = "custom name")
@@ -44,7 +46,7 @@ public class ReactiveMockTest {
 
     @BeforeMethod
     public void initContext() {
-        ReactiveMockitoAnnotations.initMocks(this);
+        mocks = MockitoAnnotations.openMocks(this);
     }
 
     @Test
@@ -71,11 +73,9 @@ public class ReactiveMockTest {
         assertThat(serializableStubOnlyReactiveApi, is(not(nullValue())));
     }
 
-    private interface ReactiveApi {
-        Flux<String> getAll(int id);
-
-        default Mono<String> getFirst(int id) {
-            return getAll(id).take(1).single();
-        }
+    @AfterMethod
+    public void closeMocks() throws Exception {
+        mocks.close();
     }
+
 }

--- a/molten-test/src/test/java/com/hotels/molten/test/mockito/ReactiveMockByOpenMocksTest.java
+++ b/molten-test/src/test/java/com/hotels/molten/test/mockito/ReactiveMockByOpenMocksTest.java
@@ -16,61 +16,34 @@
 
 package com.hotels.molten.test.mockito;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
-import static org.mockito.Mockito.when;
-
 import java.util.function.Function;
+import java.util.stream.Stream;
 
+import org.mockito.Answers;
+import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import reactor.core.publisher.Flux;
-import reactor.test.StepVerifier;
 
 /**
  * Unit test for {@link ReactiveMock} initiated by {@link MockitoAnnotations#openMocks}.
  */
 public class ReactiveMockByOpenMocksTest {
-    private static final int ID = 1;
-    private static final String VALUE_A = "a";
-    private static final String VALUE_B = "b";
     private AutoCloseable mocks;
     @ReactiveMock
-    private ReactiveApi reactiveApi;
-    @ReactiveMock(serializable = true, stubOnly = true, extraInterfaces = Function.class, name = "custom name")
-    private ReactiveApi serializableStubOnlyReactiveApi;
+    private ReactiveApi legacyReactiveMock;
+    @ReactiveMock(serializable = true, stubOnly = true, extraInterfaces = Function.class, name = "custom legacy mock")
+    private ReactiveApi customLegacyReactiveMock;
+    @Mock
+    private ReactiveApi reactiveMock;
+    @Mock(answer = Answers.CALLS_REAL_METHODS, name = "custom mock")
+    private ReactiveApi callsRealReactiveMock;
 
     @BeforeMethod
     public void initContext() {
         mocks = MockitoAnnotations.openMocks(this);
-    }
-
-    @Test
-    public void shouldEmitStubValue() {
-        when(reactiveApi.getAll(ID)).thenReturn(Flux.just(VALUE_A, VALUE_B));
-
-        StepVerifier.create(reactiveApi.getAll(ID)).expectSubscription().expectNext(VALUE_A, VALUE_B).expectComplete().verify();
-    }
-
-    @Test
-    public void shouldEmitEmptyByDefault() {
-        StepVerifier.create(reactiveApi.getAll(ID)).expectSubscription().expectComplete().verify();
-    }
-
-    @Test
-    public void shouldSupportDefaultMethod() {
-        when(reactiveApi.getAll(ID)).thenReturn(Flux.just(VALUE_A, VALUE_B));
-
-        StepVerifier.create(reactiveApi.getFirst(ID)).expectSubscription().expectNext(VALUE_A).expectComplete().verify();
-    }
-
-    @Test
-    public void shouldSupportMockitoAnnotationProperties() {
-        assertThat(serializableStubOnlyReactiveApi, is(not(nullValue())));
     }
 
     @AfterMethod
@@ -78,4 +51,50 @@ public class ReactiveMockByOpenMocksTest {
         mocks.close();
     }
 
+    @DataProvider
+    public static Object[][] mocks() {
+        return Stream.<MockHolder>of(
+            test -> test.legacyReactiveMock,
+            test -> test.customLegacyReactiveMock,
+            test -> test.reactiveMock,
+            test -> test.callsRealReactiveMock
+        )
+            .map(mock -> new Object[]{mock})
+            .toArray(Object[][]::new);
+    }
+
+    @DataProvider
+    public static Object[][] callRealMocks() {
+        return Stream.<MockHolder>of(
+            test -> test.legacyReactiveMock,
+            test -> test.customLegacyReactiveMock,
+            test -> test.callsRealReactiveMock
+        )
+            .map(mock -> new Object[]{mock})
+            .toArray(Object[][]::new);
+    }
+
+    @Test(dataProvider = "mocks")
+    public void shouldEmitStubValue(MockHolder mockHolder) {
+        ReactiveMockTestCases.shouldEmitStubValue(mockHolder.extract(this));
+    }
+
+    @Test(dataProvider = "mocks")
+    public void shouldEmitEmptyByDefault(MockHolder mockHolder) {
+        ReactiveMockTestCases.shouldEmitEmptyByDefault(mockHolder.extract(this));
+    }
+
+    @Test(dataProvider = "callRealMocks")
+    public void shouldSupportDefaultMethod(MockHolder mockHolder) {
+        ReactiveMockTestCases.shouldSupportDefaultMethod(mockHolder.extract(this));
+    }
+
+    @Test(dataProvider = "mocks")
+    public void shouldSupportMockitoAnnotationProperties(MockHolder mockHolder) {
+        ReactiveMockTestCases.shouldSupportMockitoAnnotationProperties(mockHolder.extract(this));
+    }
+
+    private interface MockHolder {
+        ReactiveApi extract(ReactiveMockByOpenMocksTest test);
+    }
 }

--- a/molten-test/src/test/java/com/hotels/molten/test/mockito/ReactiveMockByReactiveInitMocksTest.java
+++ b/molten-test/src/test/java/com/hotels/molten/test/mockito/ReactiveMockByReactiveInitMocksTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2020 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hotels.molten.test.mockito;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.when;
+
+import java.util.function.Function;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+/**
+ * Unit test for {@link ReactiveMock} initiated by {@link ReactiveMockitoAnnotations#initMocks}.
+ */
+public class ReactiveMockByReactiveInitMocksTest {
+    private static final int ID = 1;
+    private static final String VALUE_A = "a";
+    private static final String VALUE_B = "b";
+    @ReactiveMock
+    private ReactiveApi reactiveApi;
+    @ReactiveMock(serializable = true, stubOnly = true, extraInterfaces = Function.class, name = "custom name")
+    private ReactiveApi serializableStubOnlyReactiveApi;
+
+    @BeforeMethod
+    public void initContext() {
+        ReactiveMockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void shouldEmitStubValue() {
+        when(reactiveApi.getAll(ID)).thenReturn(Flux.just(VALUE_A, VALUE_B));
+
+        StepVerifier.create(reactiveApi.getAll(ID)).expectSubscription().expectNext(VALUE_A, VALUE_B).expectComplete().verify();
+    }
+
+    @Test
+    public void shouldEmitEmptyByDefault() {
+        StepVerifier.create(reactiveApi.getAll(ID)).expectSubscription().expectComplete().verify();
+    }
+
+    @Test
+    public void shouldSupportDefaultMethod() {
+        when(reactiveApi.getAll(ID)).thenReturn(Flux.just(VALUE_A, VALUE_B));
+
+        StepVerifier.create(reactiveApi.getFirst(ID)).expectSubscription().expectNext(VALUE_A).expectComplete().verify();
+    }
+
+    @Test
+    public void shouldSupportMockitoAnnotationProperties() {
+        assertThat(serializableStubOnlyReactiveApi, is(not(nullValue())));
+    }
+
+}

--- a/molten-test/src/test/java/com/hotels/molten/test/mockito/ReactiveMockTestCases.java
+++ b/molten-test/src/test/java/com/hotels/molten/test/mockito/ReactiveMockTestCases.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hotels.molten.test.mockito;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.when;
+
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+class ReactiveMockTestCases {
+    private static final int ID = 1;
+    private static final String VALUE_A = "a";
+    private static final String VALUE_B = "b";
+
+    static void shouldEmitStubValue(ReactiveApi reactiveApi) {
+        when(reactiveApi.getAll(ID)).thenReturn(Flux.just(VALUE_A, VALUE_B));
+
+        StepVerifier.create(reactiveApi.getAll(ID)).expectSubscription().expectNext(VALUE_A, VALUE_B).expectComplete().verify();
+    }
+
+    static void shouldEmitEmptyByDefault(ReactiveApi reactiveApi) {
+        StepVerifier.create(reactiveApi.getAll(ID)).expectSubscription().expectComplete().verify();
+    }
+
+    static void shouldSupportDefaultMethod(ReactiveApi reactiveApi) {
+        when(reactiveApi.getAll(ID)).thenReturn(Flux.just(VALUE_A, VALUE_B));
+
+        StepVerifier.create(reactiveApi.getFirst(ID)).expectSubscription().expectNext(VALUE_A).expectComplete().verify();
+    }
+
+    static void shouldSupportMockitoAnnotationProperties(ReactiveApi reactiveApi) {
+        assertThat(reactiveApi, is(not(nullValue())));
+    }
+}

--- a/molten-trace-test/pom.xml
+++ b/molten-trace-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.expediagroup.molten</groupId>
     <artifactId>molten-root</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../molten-root/pom.xml</relativePath>
   </parent>
   <artifactId>molten-trace-test</artifactId>

--- a/molten-trace-test/src/test/java/com/hotels/molten/trace/TracingTransformerTest.java
+++ b/molten-trace-test/src/test/java/com/hotels/molten/trace/TracingTransformerTest.java
@@ -37,6 +37,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeMethod;
@@ -45,7 +46,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-import com.hotels.molten.test.mockito.ReactiveMockitoAnnotations;
 import com.hotels.molten.trace.test.AbstractTracingTest;
 import com.hotels.molten.trace.test.SpanMatcher;
 
@@ -54,6 +54,7 @@ import com.hotels.molten.trace.test.SpanMatcher;
  */
 @Slf4j
 public class TracingTransformerTest extends AbstractTracingTest {
+    private AutoCloseable mocks;
     private Logger rootLogger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
     @Mock
     private Appender<ILoggingEvent> appender;
@@ -62,14 +63,15 @@ public class TracingTransformerTest extends AbstractTracingTest {
 
     @BeforeMethod
     public void init() {
-        ReactiveMockitoAnnotations.initMocks(this);
+        mocks = MockitoAnnotations.openMocks(this);
         when(appender.getName()).thenReturn("MOCK");
         rootLogger.addAppender(appender);
     }
 
     @AfterClass
-    public void tearDown() {
+    public void tearDown() throws Exception {
         rootLogger.detachAppender(appender);
+        mocks.close();
     }
 
     @Test

--- a/molten-trace/pom.xml
+++ b/molten-trace/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.expediagroup.molten</groupId>
     <artifactId>molten-root</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../molten-root/pom.xml</relativePath>
   </parent>
   <artifactId>molten-trace</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,6 @@
     <module>molten-bom</module>
     <module>molten-dependencies</module>
     <module>molten-root</module>
-    <module>molten-test-mockito-autoconfigure</module>
   </modules>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,7 @@
             <exclude>**/*.yml</exclude>
             <exclude>**/*.xml</exclude>
             <exclude>docker/data/**</exclude>
+            <exclude>LICENSE</exclude>
           </excludes>
         </configuration>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
     <module>molten-bom</module>
     <module>molten-dependencies</module>
     <module>molten-root</module>
+    <module>molten-test-mockito-autoconfigure</module>
   </modules>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.expediagroup.molten</groupId>
   <artifactId>molten-base</artifactId>
-  <version>1.0.1-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <name>Molten - base</name>
   <description>Molten - a reactive toolbox for integration</description>
   <packaging>pom</packaging>

--- a/readme.md
+++ b/readme.md
@@ -97,6 +97,7 @@ To define all dependency versions in a consistent way one can use the dependenci
 
 # Test support modules
 * [molten-test](molten-test/readme.md) - reactive test support
+* [molten-test-mockito-autoconfigure](molten-test-mockito-autoconfigure/readme.md) - auto-configured Mockito for reactive test support
 * [molten-trace-test](molten-trace-test/readme.md) - reactive tracing test support
 
 # Experimental features


### PR DESCRIPTION
### :pencil: Description
- Fixes the legacy `@ReactiveMock` functionality on the latest mockito (3.7.0)
	- Users can update to the latest mockito, and will have passing tests with the deprecated `@ReactiveMock` and `ReactiveMockitoAnnotations.initMocks` setup
	- As these are deprecated, users are discouraged to use these.
	- Custom default answers, mocking static methods and other new mockito 3.4.0+ features are not supported or can be broken.
- Using standard `@Mock` will create reactive mock either, with full support of other mockito functionalities
	- Sets the `ReactiveAnswer` as the default one above the mockito's default answer
	- This is achieved by configuring Mockito through `MockitoConfiguration`, which, if present, makes mockito no further configurable. To bypass this, made the `MockitoConfiguration` in a separate, excludable maven dependency (`molten-test-mockito-autoconfigure`), added to `molten-test` as a dependency by default. By that, using `molten-test` does not prevent the user the configure Mockito if really wants to.
- Refactored the tests of molten
	- Replaced `@ReactiveMock` with `@Mock`
	- Replaced `MockitoAnnotations.initMocks` with `MockitoTestNGListener` for TestNG tests

### :link: Related Issues
- none
