### PR TITLE
Netty reactive client test revived and versions updated

### DIFF
--- a/molten-dependencies/pom.xml
+++ b/molten-dependencies/pom.xml
@@ -29,8 +29,8 @@
     <kryo-serializers.version>0.42</kryo-serializers.version>
     <jsr305.version>3.0.2</jsr305.version>
     <vertx.version>3.9.4</vertx.version>
-    <netty.version>4.1.55.Final</netty.version>
-    <reactor-netty.version>1.0.2</reactor-netty.version>
+    <netty.version>4.1.59.Final</netty.version>
+    <reactor-netty.version>1.0.3</reactor-netty.version>
     <protobuf.version>3.0.0</protobuf.version>
     <retrofit.version>2.9.0</retrofit.version>
     <okhttp.version>4.9.0</okhttp.version>

--- a/molten-http-client/src/main/java/com/hotels/molten/http/client/ReactorNettyCallFactoryFactory.java
+++ b/molten-http-client/src/main/java/com/hotels/molten/http/client/ReactorNettyCallFactoryFactory.java
@@ -46,10 +46,10 @@ class ReactorNettyCallFactoryFactory implements CallFactoryFactory {
     public okhttp3.Call.Factory createCallFactory(RetrofitServiceClientConfiguration<?> configuration, String clientId) {
         var connectionProvider = createConnectionProvider(configuration, clientId);
         var httpClient = HttpClient.create(connectionProvider)
-            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) configuration.getConnectionSettings().getTimeout().toMillis()) // connection timeout in ms
-            .option(ChannelOption.TCP_NODELAY, true) // TODO: should this be configurable?
-            .runOn(LOOP_RESOURCES)
-            .metrics(false, s -> s) //TODO: consider making this configurable
+            .runOn(LOOP_RESOURCES) // should be singleton shared among clients
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Math.toIntExact(configuration.getConnectionSettings().getTimeout().toMillis()))
+            .option(ChannelOption.TCP_NODELAY, true) // TODO: consider making this configurable
+            .metrics(false, () -> null) //TODO: consider making this configurable
             .followRedirect(false)
             .compress(true)
             .disableRetry(!configuration.getConnectionSettings().isRetryOnConnectionFailure())

--- a/molten-http-client/src/test/java/com/hotels/molten/http/client/ReactorNettyHttpClientTest.java
+++ b/molten-http-client/src/test/java/com/hotels/molten/http/client/ReactorNettyHttpClientTest.java
@@ -30,12 +30,12 @@ import io.netty.channel.ChannelOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 import reactor.core.publisher.Flux;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.resources.ConnectionProvider;
 import reactor.netty.resources.LoopResources;
+import reactor.test.StepVerifier;
 import retrofit2.Retrofit;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 
@@ -49,7 +49,6 @@ import com.hotels.molten.trace.test.TracingTestSupport;
  * Metrics: reactor.netty.http.client.HttpClient#metrics(boolean, reactor.netty.http.client.HttpClientMetricsRecorder)
  * reactor.netty.channel.MicrometerChannelMetricsRecorder
  */
-@Ignore
 public class ReactorNettyHttpClientTest {
     private static final Logger LOG = LoggerFactory.getLogger("TEST");
 
@@ -62,7 +61,7 @@ public class ReactorNettyHttpClientTest {
     }
 
     @Test
-    public void should() throws InterruptedException {
+    public void shouldWork() throws InterruptedException {
         var connectionProvider = ConnectionProvider.builder("fixed")
             .name("my-connection-pool")
             .maxConnections(1)
@@ -77,23 +76,22 @@ public class ReactorNettyHttpClientTest {
             .build();
         HttpClient.create(connectionProvider)
             //.secure(spec -> spec.sslContext(SslContextBuilder.forClient()))
-            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10000)
+            .runOn(LoopResources.create("molten-http")) // should be singleton shared among clients
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10000) // connection timeout
             .option(ChannelOption.TCP_NODELAY, true)
-            .runOn(LoopResources.create("molten-http"))
             .followRedirect(false)
             .compress(true)
             .baseUrl(BASE_URL)
             .get()
-            //.post().send(ByteBufFlux.fromString(Mono.just("hello")))
             .uri("/delay/100")
-            //.response((response, body) -> {})
             .responseContent()
             .asString()
             .doOnSubscribe(s -> LOG.info("subscribing 0"))
-            .timeout(Duration.ofMillis(1320))
+            .timeout(Duration.ofMillis(1000))
             .doFinally(s -> LOG.info("finally 0 {}", s))
-            .subscribe(r -> LOG.info("result 0 {}", r), e -> LOG.error("error 0", e), () -> LOG.info("completed 0"));
-        Thread.sleep(5000);
+            .as(StepVerifier::create)
+            .expectNext("\"success\"")
+            .verifyComplete();
     }
 
     @Test
@@ -152,9 +150,9 @@ public class ReactorNettyHttpClientTest {
             .build();
         var httpClient = HttpClient.create(connectionProvider)
             //.secure(spec -> spec.sslContext(SslContextBuilder.forClient()))
+            .runOn(LoopResources.create("molten-http"))
             .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10000)
             .option(ChannelOption.TCP_NODELAY, true)
-            .runOn(LoopResources.create("molten-http"))
             .followRedirect(false)
             .compress(true)
             .metrics(true, u -> u)
@@ -168,20 +166,23 @@ public class ReactorNettyHttpClientTest {
 
         ServiceEndpoint serviceClient = retrofit.create(ServiceEndpoint.class);
 
-        serviceClient.postData(new Request("text", 123))
+        serviceClient.postData(new Request("mirror me!", 1234))
             .doOnSubscribe(s -> LOG.info("subscribing"))
             .timeout(Duration.ofMillis(1000))
             .doFinally(s -> LOG.info("finally {}", s))
-            .subscribe(r -> LOG.info("result {}", r), e -> LOG.error("error", e), () -> LOG.info("completed"));
-        //Thread.sleep(50000);
-        Flux.interval(Duration.ZERO, Duration.ofMillis(200))
-            .take(1000)
+            .as(StepVerifier::create)
+            .expectNext(new Response("mirror me!", 1234))
+            .verifyComplete();
+
+        Flux.interval(Duration.ZERO, Duration.ofMillis(100))
+            .take(100)
             .flatMap(i -> serviceClient.getDelayed(new Random().nextInt(400) + 100)
                 .doOnSubscribe(s -> LOG.info("subscribing"))
                 .timeout(Duration.ofMillis(1000))
                 .doFinally(s -> LOG.info("finally {}", s))
             )
-            .subscribe(r -> LOG.info("result {}", r), e -> LOG.error("error", e), () -> LOG.info("completed"));
-        Thread.sleep(50000);
+            .as(StepVerifier::create)
+            .expectNextCount(100)
+            .verifyComplete();
     }
 }


### PR DESCRIPTION
### :pencil: Description
- Updated `netty` and `reactor-netty` versions to the latest.
- Enabled netty client tests.

### :link: Related Issues

would close these dependabot PRs: #31 and #39