### PR TITLE
Make it possible to read the HttpException error body.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added spring-boot 2 auto-configuration support with `molten-spring-boot` module.
+- Rewamped mockito support with auto-configuration. `@Mock` now supports reactor types. 
+
+### Deprecated
+- `@ReactiveMock` and related classes are now deprecated.
 
 ## [1.0.0]
 - Initial release

--- a/build/suppressions.xml
+++ b/build/suppressions.xml
@@ -5,4 +5,5 @@
   <suppress checks="FileLength|MethodLength" files="com.hotels.molten.http.client.StubJsonServiceServer.java" />
   <suppress checks="NoClone" files="com.hotels.molten.http.client.retrofit.ReactorNettyCall.java" />
   <suppress checks="VisibilityModifier" files="com.hotels.molten.core.common.AbstractNonFusingSubscription.java" />
+  <suppress checks="IllegalInstantiation" files="com.hotels.molten.http.client.HttpException.java" />
 </suppressions>

--- a/molten-http-client/src/main/java/com/hotels/molten/http/client/CallLog.java
+++ b/molten-http-client/src/main/java/com/hotels/molten/http/client/CallLog.java
@@ -112,8 +112,4 @@ final class CallLog {
     private Throwable causeOrSelf(Throwable e) {
         return e.getCause() != null ? e.getCause() : e;
     }
-
-    private String getMessage(Throwable ex) {
-        return ex instanceof HttpException ? "httpStatus=" + ((HttpException) ex).getStatusCode() : ex.getMessage();
-    }
 }

--- a/molten-http-client/src/test/java/com/hotels/molten/http/client/CallLoggingReactiveProxyFactoryTest.java
+++ b/molten-http-client/src/test/java/com/hotels/molten/http/client/CallLoggingReactiveProxyFactoryTest.java
@@ -111,7 +111,7 @@ public class CallLoggingReactiveProxyFactoryTest {
             new Object[]{new PermanentServiceInvocationException("doh", Camoo.class,
                     new HttpException(new retrofit2.HttpException(Response.error(400, ResponseBody.create("this is bad", MediaType.parse("text/plain")))))),
                          "target=com.hotels.molten.http.client.Camoo#get circuit=grpid duration=\\d+ result=FAIL shortCircuited=false rejected=false timedOut=false retry=0 "
-                    + "error=com.hotels.molten.http.client.HttpException httpStatus=400 error_message=Response.error\\(\\) error_body=this is bad"}
+                    + "error=com.hotels.molten.http.client.HttpException http_status=400 error_message=Response.error\\(\\) error_body=this is bad"}
         };
     }
 

--- a/molten-http-client/src/test/java/com/hotels/molten/http/client/RetrofitServiceClientBuilderTest.java
+++ b/molten-http-client/src/test/java/com/hotels/molten/http/client/RetrofitServiceClientBuilderTest.java
@@ -241,7 +241,7 @@ public class RetrofitServiceClientBuilderTest extends AbstractTracingTest {
             .verifyErrorSatisfies(ex -> assertThat(ex).isInstanceOf(PermanentServiceInvocationException.class)
                 .hasCauseInstanceOf(HttpException.class)
                 .satisfies(e -> assertThat(e.getCause()).hasCauseInstanceOf(retrofit2.HttpException.class)
-                    .hasMessage("httpStatus=400 error_message=Bad Request error_body=\"error\"")));
+                    .hasMessage("http_status=400 error_message=Bad Request error_body=\"error\"")));
     }
 
     @Test(dataProvider = "common")

--- a/molten-root/pom.xml
+++ b/molten-root/pom.xml
@@ -19,7 +19,6 @@
   <properties>
     <checkstyle.suppressions.location>build/suppressions.xml</checkstyle.suppressions.location>
     <skip.integration.tests>false</skip.integration.tests>
-    <integration.test.concurrency>4</integration.test.concurrency>
   </properties>
 
   <modules>
@@ -88,8 +87,8 @@
           <includes>
             <include>**/*IntegrationTest</include>
           </includes>
-          <parallel>classes</parallel>
-          <threadCount>${integration.test.concurrency}</threadCount>
+          <parallel>none</parallel>
+          <threadCount>1</threadCount>
         </configuration>
         <executions>
           <execution>

--- a/molten-spring-boot/src/test/java/com/hotels/molten/spring/boot/integration/SpringBootWebFluxIntegrationTest.java
+++ b/molten-spring-boot/src/test/java/com/hotels/molten/spring/boot/integration/SpringBootWebFluxIntegrationTest.java
@@ -70,6 +70,12 @@ public class SpringBootWebFluxIntegrationTest {
 
     @BeforeEach
     void initTestCase() {
+        LOG.info("Warmup");
+        webClient.get().uri("/say-hello").exchange()
+            .expectStatus().isOk()
+            .expectBody(String.class).isEqualTo("Hello Bob!");
+        awaitForMessage("/say-hello", 10);
+        LOG.info("Warmup finished");
         LogCaptor.clearCapturedLogs();
     }
 
@@ -103,7 +109,7 @@ public class SpringBootWebFluxIntegrationTest {
         // The order of MdcWebFilter must be lower (higher precedence) than the other filters doing any logging (e.g. TraceWebFilter in this case).
         webClient.get().uri("/say-hello").exchange()
             .expectStatus().isOk().expectBody();
-        awaitForMessage("/say-hello");
+        awaitForMessage("/say-hello", 3);
         clearCapturedLogs();
         // Post has more complicated threading due to reactive body handling.
         var requestId = webClient.post().uri("/request-id").bodyValue("thing").exchange()

--- a/molten-spring-boot/src/test/java/com/hotels/molten/spring/boot/integration/SpringBootWebFluxIntegrationTest.java
+++ b/molten-spring-boot/src/test/java/com/hotels/molten/spring/boot/integration/SpringBootWebFluxIntegrationTest.java
@@ -41,6 +41,7 @@ import org.testcontainers.utility.DockerImageName;
 import zipkin2.Span;
 
 import com.hotels.molten.spring.boot.integration.test.LogCaptor;
+import com.hotels.molten.spring.boot.integration.test.SpanCaptor;
 import com.hotels.molten.spring.boot.integration.test.TestApplication;
 
 /**
@@ -74,9 +75,9 @@ public class SpringBootWebFluxIntegrationTest {
         webClient.get().uri("/say-hello").exchange()
             .expectStatus().isOk()
             .expectBody(String.class).isEqualTo("Hello Bob!");
-        awaitForMessage("/say-hello", 10);
         LOG.info("Warmup finished");
         LogCaptor.clearCapturedLogs();
+        SpanCaptor.clearCapturedSpans();
     }
 
     public static String getMockServerUrl() {

--- a/molten-spring-boot/src/test/java/com/hotels/molten/spring/boot/integration/test/LogCaptor.java
+++ b/molten-spring-boot/src/test/java/com/hotels/molten/spring/boot/integration/test/LogCaptor.java
@@ -46,8 +46,8 @@ public final class LogCaptor extends AppenderBase<ILoggingEvent> {
         CAPTURED_LOGS.clear();
     }
 
-    public static void awaitForMessage(String expectedMessagePart) {
-        await().atMost(ofSeconds(3)).untilAsserted(() -> assertThat(capturedLogs())
+    public static void awaitForMessage(String expectedMessagePart, int waitSeconds) {
+        await().atMost(ofSeconds(waitSeconds)).untilAsserted(() -> assertThat(capturedLogs())
             .anySatisfy(log -> assertThat(log.getEvent().getFormattedMessage()).contains(expectedMessagePart))
         );
     }


### PR DESCRIPTION
### :pencil: Description
Since okhttp doesn't make it possible to read an error response body twice, HttpException should expose it directly as a byte array.

This change adds the `byte[] getErrorBody()` and `Charset getCharset()` methods to `com.hotels.molten.http.client.HttpException`.
