### PR TITLE
Migrated most of the tests to JUnit 5

### DIFF
--- a/molten-cache/src/test/java/com/hotels/molten/cache/NamedReactiveCacheTest.java
+++ b/molten-cache/src/test/java/com/hotels/molten/cache/NamedReactiveCacheTest.java
@@ -22,18 +22,18 @@ import static org.mockito.Mockito.when;
 import java.time.Duration;
 import java.util.function.Function;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.testng.MockitoTestNGListener;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Listeners;
-import org.testng.annotations.Test;
+import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 /**
  * Unit test for {@link NamedReactiveCache}.
  */
-@Listeners(MockitoTestNGListener.class)
+@ExtendWith(MockitoExtension.class)
 public class NamedReactiveCacheTest {
     private static final int KEY = 1;
     private static final String VALUE = "one";
@@ -44,13 +44,13 @@ public class NamedReactiveCacheTest {
     private ReactiveCache<NamedCacheKey<Integer>, CachedValue<String>> cache;
     private NamedReactiveCache<Integer, String> namedReactiveCache;
 
-    @BeforeMethod
+    @BeforeEach
     public void initContext() {
         namedReactiveCache = new NamedReactiveCache<>(cache, CACHENAME, TTL);
     }
 
     @Test
-    public void shouldDelegateGetWithNamedKeyLazily() {
+    public void should_delegate_get_with_named_key_lazily() {
         when(cache.get(NAMED_CACHE_KEY_FACTORY.apply(KEY))).thenReturn(Mono.just(CachedValue.just(VALUE)));
         StepVerifier.create(namedReactiveCache.get(KEY))
             .expectSubscription()
@@ -60,7 +60,7 @@ public class NamedReactiveCacheTest {
     }
 
     @Test
-    public void shouldDelegatePutWithNamedKeyAndValueWithTTLLazily() {
+    public void should_delegate_put_with_named_key_and_value_with_ttllazily() {
         when(cache.put(NAMED_CACHE_KEY_FACTORY.apply(KEY), CachedValue.of(VALUE, TTL))).thenReturn(Mono.empty());
         StepVerifier.create(namedReactiveCache.put(KEY, VALUE))
             .expectSubscription()

--- a/molten-cache/src/test/java/com/hotels/molten/cache/ReactiveCacheContract.java
+++ b/molten-cache/src/test/java/com/hotels/molten/cache/ReactiveCacheContract.java
@@ -36,7 +36,7 @@ public interface ReactiveCacheContract {
     <T> ReactiveCache<Integer, T> createCacheForContractTest();
 
     @Test
-    default void shouldCacheValueViaOperator() {
+    default void should_cache_value_via_operator() {
         ReactiveCache<Integer, String> reactiveCache = spy(createCacheForContractTest());
         Mono.just(VALUE)
             .as(reactiveCache.cachingWith(KEY))
@@ -58,7 +58,7 @@ public interface ReactiveCacheContract {
     }
 
     @Test
-    default void shouldConvertValueViaOperator() {
+    default void should_convert_value_via_operator() {
         ReactiveCache<Integer, String> reactiveCache = spy(createCacheForContractTest());
         Mono.just(VALUE)
             .as(reactiveCache.cachingWith(KEY, String::toUpperCase, String::toLowerCase))
@@ -72,7 +72,7 @@ public interface ReactiveCacheContract {
     }
 
     @Test
-    default void shouldNotFailIfThereAreNoEmittedItems() {
+    default void should_not_fail_if_there_are_no_emitted_items() {
         ReactiveCache<Integer, String> reactiveCache = createCacheForContractTest();
         Mono.<String>empty()
             .as(reactiveCache.cachingWith(KEY))
@@ -83,7 +83,7 @@ public interface ReactiveCacheContract {
     }
 
     @Test
-    default void shouldWorkAsNegativeCacheViaOperator() {
+    default void should_work_as_negative_cache_via_operator() {
         ReactiveCache<Integer, StringWrapper> reactiveNegativeCache = spy(createCacheForContractTest());
         Mono.<String>empty()
             .as(reactiveNegativeCache.cachingWith(KEY, StringWrapper::new, StringWrapper::getValue))

--- a/molten-cache/src/test/java/com/hotels/molten/cache/ReactiveCaffeineCacheTest.java
+++ b/molten-cache/src/test/java/com/hotels/molten/cache/ReactiveCaffeineCacheTest.java
@@ -21,18 +21,18 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.github.benmanes.caffeine.cache.Cache;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.testng.MockitoTestNGListener;
-import org.testng.annotations.Listeners;
-import org.testng.annotations.Test;
+import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 /**
  * Unit test for {@link ReactiveCaffeineCache}.
  */
-@Listeners(MockitoTestNGListener.class)
+@ExtendWith(MockitoExtension.class)
 public class ReactiveCaffeineCacheTest {
     private static final String VALUE = "one";
     private static final int KEY = 1;
@@ -42,7 +42,7 @@ public class ReactiveCaffeineCacheTest {
     private ReactiveCaffeineCache<Integer, String> reactiveCache;
 
     @Test
-    public void shouldDelegateGetLazily() {
+    public void should_delegate_get_lazily() {
         when(cache.getIfPresent(KEY)).thenReturn(VALUE);
         Mono<String> get = reactiveCache.get(KEY);
         verifyNoInteractions(cache);
@@ -55,7 +55,7 @@ public class ReactiveCaffeineCacheTest {
     }
 
     @Test
-    public void shouldDelegatePutLazily() {
+    public void should_delegate_put_lazily() {
         Mono<Void> put = reactiveCache.put(KEY, VALUE);
         verifyNoInteractions(cache);
         StepVerifier.create(put)

--- a/molten-cache/src/test/java/com/hotels/molten/cache/ReactiveGuavaCacheTest.java
+++ b/molten-cache/src/test/java/com/hotels/molten/cache/ReactiveGuavaCacheTest.java
@@ -21,18 +21,18 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.cache.Cache;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.testng.MockitoTestNGListener;
-import org.testng.annotations.Listeners;
-import org.testng.annotations.Test;
+import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 /**
  * Unit test for {@link ReactiveGuavaCache}.
  */
-@Listeners(MockitoTestNGListener.class)
+@ExtendWith(MockitoExtension.class)
 public class ReactiveGuavaCacheTest {
     private static final String VALUE = "one";
     private static final int KEY = 1;
@@ -42,7 +42,7 @@ public class ReactiveGuavaCacheTest {
     private ReactiveGuavaCache<Integer, String> reactiveCache;
 
     @Test
-    public void shouldDelegateGetLazily() {
+    public void should_delegate_get_lazily() {
         when(cache.getIfPresent(KEY)).thenReturn(VALUE);
         Mono<String> get = reactiveCache.get(KEY);
         verifyNoInteractions(cache);
@@ -55,7 +55,7 @@ public class ReactiveGuavaCacheTest {
     }
 
     @Test
-    public void shouldDelegatePutLazily() {
+    public void should_delegate_put_lazily() {
         Mono<Void> put = reactiveCache.put(KEY, VALUE);
         verifyNoInteractions(cache);
         StepVerifier.create(put)

--- a/molten-cache/src/test/java/com/hotels/molten/cache/ReactiveMapCacheTest.java
+++ b/molten-cache/src/test/java/com/hotels/molten/cache/ReactiveMapCacheTest.java
@@ -49,7 +49,7 @@ class ReactiveMapCacheTest implements ReactiveCacheContract {
     }
 
     @Test
-    void shouldDelegateGetLazily() {
+    void should_delegate_get_lazily() {
         when(cache.get(KEY)).thenReturn(VALUE);
         Mono<String> get = reactiveCache.get(KEY);
         verifyNoInteractions(cache);
@@ -62,7 +62,7 @@ class ReactiveMapCacheTest implements ReactiveCacheContract {
     }
 
     @Test
-    void shouldDelegatePutLazily() {
+    void should_delegate_put_lazily() {
         Mono<Void> put = reactiveCache.put(KEY, VALUE);
         verifyNoInteractions(cache);
         StepVerifier.create(put)

--- a/molten-cache/src/test/java/com/hotels/molten/cache/ReactiveReloadingCacheTest.java
+++ b/molten-cache/src/test/java/com/hotels/molten/cache/ReactiveReloadingCacheTest.java
@@ -34,12 +34,12 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.testng.MockitoTestNGListener;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Listeners;
-import org.testng.annotations.Test;
+import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 import reactor.test.scheduler.VirtualTimeScheduler;
 
@@ -53,7 +53,7 @@ import com.hotels.molten.test.TestClock;
  * Unit test for {@link ReactiveReloadingCache}.
  */
 @Slf4j
-@Listeners(MockitoTestNGListener.class)
+@ExtendWith(MockitoExtension.class)
 public class ReactiveReloadingCacheTest {
     private static final int KEY = 1;
     private static final String VALUE = "1";
@@ -72,7 +72,7 @@ public class ReactiveReloadingCacheTest {
     private Gauge asyncLoadCounter;
     private Gauge asyncLoadExceptionCounter;
 
-    @BeforeMethod
+    @BeforeEach
     public void initContext() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
         meterRegistry = new SimpleMeterRegistry();
@@ -82,7 +82,7 @@ public class ReactiveReloadingCacheTest {
         clock = TestClock.get();
     }
 
-    @AfterMethod
+    @AfterEach
     public void clearContext() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
         MoltenMetrics.setGraphiteIdMetricsLabelEnabled(false);

--- a/molten-cache/src/test/java/com/hotels/molten/cache/metrics/CaffeineCacheStatsInstrumenterTest.java
+++ b/molten-cache/src/test/java/com/hotels/molten/cache/metrics/CaffeineCacheStatsInstrumenterTest.java
@@ -29,51 +29,51 @@ import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.testng.MockitoTestNGListener;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Listeners;
-import org.testng.annotations.Test;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.hotels.molten.core.metrics.MoltenMetrics;
 
 /**
  * Unit test for {@link CaffeineCacheStatsInstrumenter}.
  */
-@Listeners(MockitoTestNGListener.class)
+@ExtendWith(MockitoExtension.class)
 public class CaffeineCacheStatsInstrumenterTest {
     private CaffeineCacheStatsInstrumenter instrumenter;
     private MeterRegistry meterRegistry;
     @Mock
     private Cache cache;
 
-    @BeforeMethod
+    @BeforeEach
     public void initContext() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
         meterRegistry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
         instrumenter = new CaffeineCacheStatsInstrumenter(meterRegistry, "pre.fix");
     }
 
-    @AfterMethod
+    @AfterEach
     public void clearContext() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
     }
 
     @Test
-    public void shouldRecordHits() {
+    public void should_record_hits() {
         instrumenter.recordHits(2);
         assertThat(meterRegistry.get("pre.fix.hit-count").counter().count()).isEqualTo(2D);
     }
 
     @Test
-    public void shouldRecordMisses() {
+    public void should_record_misses() {
         instrumenter.recordMisses(2);
         assertThat(meterRegistry.get("pre.fix.miss-count").counter().count()).isEqualTo(2D);
     }
 
     @Test
-    public void shouldRecordLoadSuccessTime() {
+    public void should_record_load_success_time() {
         instrumenter.recordLoadSuccess(60);
         instrumenter.recordLoadSuccess(50);
         Timer timer = meterRegistry.get("pre.fix.load-success").timer();
@@ -84,7 +84,7 @@ public class CaffeineCacheStatsInstrumenterTest {
     }
 
     @Test
-    public void shouldRecordLoadFailureTime() {
+    public void should_record_load_failure_time() {
         instrumenter.recordLoadFailure(60);
         instrumenter.recordLoadFailure(50);
         Timer timer = meterRegistry.get("pre.fix.load-failure").timer();
@@ -95,21 +95,21 @@ public class CaffeineCacheStatsInstrumenterTest {
     }
 
     @Test
-    public void shouldRecordEvictions() {
+    public void should_record_evictions() {
         instrumenter.recordEviction(2);
         assertThat(meterRegistry.get("pre.fix.eviction-count").counter().count()).isEqualTo(1D);
         assertThat(instrumenter.snapshot().evictionWeight()).isEqualTo(2L);
     }
 
     @Test
-    public void shouldRegisterCacheSize() {
+    public void should_register_cache_size() {
         instrumenter.registerCache(cache);
         when(cache.estimatedSize()).thenReturn(2L);
         assertThat(meterRegistry.get("pre.fix.size").gauge().value()).isEqualTo(2D);
     }
 
     @Test
-    public void shouldAssembleSnapshot() {
+    public void should_assemble_snapshot() {
         //this is not used though
         CacheStats snapshot = instrumenter.snapshot();
         assertThat(snapshot).isNotNull();

--- a/molten-cache/src/test/java/com/hotels/molten/cache/metrics/InstrumentedReactiveCacheTest.java
+++ b/molten-cache/src/test/java/com/hotels/molten/cache/metrics/InstrumentedReactiveCacheTest.java
@@ -28,9 +28,9 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -48,13 +48,13 @@ public class InstrumentedReactiveCacheTest {
     private ReactiveCache<String, String> cache;
     private MeterRegistry meterRegistry;
 
-    @BeforeMethod
+    @BeforeEach
     public void initContext() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
         meterRegistry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
     }
 
-    @AfterMethod
+    @AfterEach
     public void clearContext() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
     }

--- a/molten-cache/src/test/java/com/hotels/molten/cache/metrics/TumblingWindowHitRatioMetricsTest.java
+++ b/molten-cache/src/test/java/com/hotels/molten/cache/metrics/TumblingWindowHitRatioMetricsTest.java
@@ -20,8 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
 
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.hotels.molten.test.TestClock;
 
@@ -32,13 +32,13 @@ public class TumblingWindowHitRatioMetricsTest {
     private TumblingWindowHitRatioMetrics metrics;
     private TestClock clock = TestClock.get();
 
-    @BeforeMethod
-    public void initContext() {
+    @BeforeEach
+    void initContext() {
         metrics = new TumblingWindowHitRatioMetrics(clock);
     }
 
     @Test
-    public void shouldCalculateRatioAsExpected() {
+    void should_calculate_ratio_as_expected() {
         metrics.registerHit();
         assertThat(metrics.hitRatio()).isEqualTo(1D);
         metrics.registerMiss();
@@ -48,7 +48,7 @@ public class TumblingWindowHitRatioMetricsTest {
     }
 
     @Test
-    public void shouldCalculateRatioAsExpectedWhenTimeChanges() {
+    void should_calculate_ratio_as_expected_when_time_changes() {
         metrics.registerHit();
         metrics.registerHit();
         metrics.registerMiss();

--- a/molten-cache/src/test/java/com/hotels/molten/cache/resilience/ResilientReactiveCacheTest.java
+++ b/molten-cache/src/test/java/com/hotels/molten/cache/resilience/ResilientReactiveCacheTest.java
@@ -32,12 +32,12 @@ import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.testng.MockitoTestNGListener;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Listeners;
-import org.testng.annotations.Test;
+import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 import reactor.test.scheduler.VirtualTimeScheduler;
@@ -49,7 +49,7 @@ import com.hotels.molten.test.AssertSubscriber;
 /**
  * Unit test for {@link ResilientReactiveCache}.
  */
-@Listeners(MockitoTestNGListener.class)
+@ExtendWith(MockitoExtension.class)
 public class ResilientReactiveCacheTest {
     private static final Long KEY = 1L;
     private static final String VALUE = "value";
@@ -61,7 +61,7 @@ public class ResilientReactiveCacheTest {
     private VirtualTimeScheduler scheduler;
     private String cacheName;
 
-    @BeforeMethod
+    @BeforeEach
     public void initContext() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
         meterRegistry = new SimpleMeterRegistry();
@@ -70,7 +70,7 @@ public class ResilientReactiveCacheTest {
         cacheName = nextCacheName();
     }
 
-    @AfterMethod
+    @AfterEach
     public void clearContext() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
         VirtualTimeScheduler.reset();

--- a/molten-core/src/test/java/com/hotels/molten/core/collapser/RequestCollapserTest.java
+++ b/molten-core/src/test/java/com/hotels/molten/core/collapser/RequestCollapserTest.java
@@ -37,13 +37,13 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.testng.MockitoTestNGListener;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.MDC;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Listeners;
-import org.testng.annotations.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -59,7 +59,7 @@ import com.hotels.molten.test.AssertSubscriber;
  * Unit test for {@link RequestCollapser}.
  */
 @Slf4j
-@Listeners(MockitoTestNGListener.class)
+@ExtendWith(MockitoExtension.class)
 public class RequestCollapserTest {
     private static final int CONTEXT = 1;
     private static final String RESULT = "result";
@@ -75,7 +75,7 @@ public class RequestCollapserTest {
     private VirtualTimeScheduler timeoutScheduler;
     private MeterRegistry meterRegistry;
 
-    @BeforeMethod
+    @BeforeEach
     public void initContext() {
         MDC.clear();
         MoltenCore.initialize();
@@ -85,7 +85,7 @@ public class RequestCollapserTest {
         timeoutScheduler = VirtualTimeScheduler.create();
     }
 
-    @AfterMethod
+    @AfterEach
     public void clearContext() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
         MDC.clear();
@@ -275,7 +275,7 @@ public class RequestCollapserTest {
     }
 
     @Test
-    public void should_time_out_if_collapsed_call_doesnt_complete_in_time() {
+    public void should_time_out_if_collapsed_call_not_complete_in_time() {
         when(valueProvider.apply(CONTEXT)).thenReturn(Mono.delay(Duration.ofMillis(100), scheduler).map(i -> RESULT));
         collapsedProvider = RequestCollapser.builder(valueProvider)
             .withScheduler(scheduler)

--- a/molten-core/src/test/java/com/hotels/molten/core/mdc/MoltenMDCTest.java
+++ b/molten-core/src/test/java/com/hotels/molten/core/mdc/MoltenMDCTest.java
@@ -20,12 +20,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.MDC;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 import reactor.core.publisher.Hooks;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -42,32 +43,32 @@ public class MoltenMDCTest {
     private static final String OTHER_VALUE = "othervalue";
     private static final String YET_ANOTHER_VALUE = "yet_another_value";
 
-    @BeforeClass
-    public void initClassContext() {
+    @BeforeAll
+    static void initClassContext() {
         Hooks.enableContextLossTracking();
         MoltenCore.initialize();
     }
 
-    @AfterClass
-    public void clearClassContext() {
+    @AfterAll
+    static void clearClassContext() {
         Hooks.disableContextLossTracking();
     }
 
-    @AfterMethod
-    public void clearContext() {
+    @AfterEach
+    void clearContext() {
         MoltenMDC.uninitialize();
     }
 
-    @DataProvider(name = "onEachOperatorEnabled")
-    public Object[][] getOnEachOperatorEnabled() {
-        return new Object[][] {
-            new Object[] {true},
-            new Object[] {false}
+    static Object[][] onEachOperatorEnabled() {
+        return new Object[][]{
+            new Object[]{true},
+            new Object[]{false}
         };
     }
 
-    @Test(dataProvider = "onEachOperatorEnabled")
-    public void should_propagate_MDC_when_subscribed_on_elastic(boolean onEachOperatorEnabled) {
+    @ParameterizedTest
+    @MethodSource("onEachOperatorEnabled")
+    void should_propagate_MDC_when_subscribed_on_elastic(boolean onEachOperatorEnabled) {
         MoltenMDC.initialize(onEachOperatorEnabled);
         MDC.put(KEY, VALUE);
         StepVerifier.create(
@@ -81,8 +82,9 @@ public class MoltenMDCTest {
         assertThat(MDC.get(KEY)).isEqualTo(VALUE);
     }
 
-    @Test(dataProvider = "onEachOperatorEnabled")
-    public void should_propagate_MDC_when_subscribed_on_parallel(boolean onEachOperatorEnabled) {
+    @ParameterizedTest
+    @MethodSource("onEachOperatorEnabled")
+    void should_propagate_MDC_when_subscribed_on_parallel(boolean onEachOperatorEnabled) {
         MoltenMDC.initialize(onEachOperatorEnabled);
         MDC.put(KEY, VALUE);
         StepVerifier.create(
@@ -96,8 +98,9 @@ public class MoltenMDCTest {
         assertThat(MDC.get(KEY)).isEqualTo(VALUE);
     }
 
-    @Test(dataProvider = "onEachOperatorEnabled")
-    public void should_propagate_MDC_when_publishing_on_elastic(boolean onEachOperatorEnabled) {
+    @ParameterizedTest
+    @MethodSource("onEachOperatorEnabled")
+    void should_propagate_MDC_when_publishing_on_elastic(boolean onEachOperatorEnabled) {
         MoltenMDC.initialize(onEachOperatorEnabled);
         MDC.put(KEY, VALUE);
         StepVerifier.create(
@@ -111,8 +114,9 @@ public class MoltenMDCTest {
         assertThat(MDC.get(KEY)).isEqualTo(VALUE);
     }
 
-    @Test(dataProvider = "onEachOperatorEnabled")
-    public void should_propagate_MDC_when_publishing_on_parallel(boolean onEachOperatorEnabled) {
+    @ParameterizedTest
+    @MethodSource("onEachOperatorEnabled")
+    void should_propagate_MDC_when_publishing_on_parallel(boolean onEachOperatorEnabled) {
         MoltenMDC.initialize(onEachOperatorEnabled);
         MDC.put(KEY, VALUE);
         StepVerifier.create(
@@ -126,8 +130,9 @@ public class MoltenMDCTest {
         assertThat(MDC.get(KEY)).isEqualTo(VALUE);
     }
 
-    @Test(dataProvider = "onEachOperatorEnabled")
-    public void should_propagate_MDC_when_subscribed_on_single(boolean onEachOperatorEnabled) {
+    @ParameterizedTest
+    @MethodSource("onEachOperatorEnabled")
+    void should_propagate_MDC_when_subscribed_on_single(boolean onEachOperatorEnabled) {
         MoltenMDC.initialize(onEachOperatorEnabled);
         MDC.put(KEY, VALUE);
         StepVerifier.create(
@@ -141,8 +146,9 @@ public class MoltenMDCTest {
         assertThat(MDC.get(KEY)).isEqualTo(VALUE);
     }
 
-    @Test(dataProvider = "onEachOperatorEnabled")
-    public void should_propagate_MDC_when_subscribed_on_immediate(boolean onEachOperatorEnabled) {
+    @ParameterizedTest
+    @MethodSource("onEachOperatorEnabled")
+    void should_propagate_MDC_when_subscribed_on_immediate(boolean onEachOperatorEnabled) {
         MoltenMDC.initialize(onEachOperatorEnabled);
         MDC.put(KEY, VALUE);
         StepVerifier.create(
@@ -156,8 +162,9 @@ public class MoltenMDCTest {
         assertThat(MDC.get(KEY)).isEqualTo(VALUE);
     }
 
-    @Test(dataProvider = "onEachOperatorEnabled")
-    public void should_propagate_MDC_when_switching_schedulers(boolean onEachOperatorEnabled) {
+    @ParameterizedTest
+    @MethodSource("onEachOperatorEnabled")
+    void should_propagate_MDC_when_switching_schedulers(boolean onEachOperatorEnabled) {
         MoltenMDC.initialize(onEachOperatorEnabled);
         MDC.put(KEY, VALUE);
         StepVerifier.create(
@@ -176,7 +183,7 @@ public class MoltenMDCTest {
     }
 
     @Test
-    public void should_propagate_MDC_with_non_reactive_callback_with_transform() {
+    void should_propagate_MDC_with_non_reactive_callback_with_transform() {
         MoltenMDC.initialize(false);
         MDC.put(KEY, VALUE);
         StepVerifier.create(
@@ -205,7 +212,7 @@ public class MoltenMDCTest {
     }
 
     @Test
-    public void should_maintain_assembly_time_MDC_value_with_non_reactive_callback_with_oneach_hook() {
+    void should_maintain_assembly_time_MDC_value_with_non_reactive_callback_with_oneach_hook() {
         MoltenMDC.initialize(true);
         MDC.put(KEY, VALUE);
         StepVerifier.create(
@@ -231,8 +238,9 @@ public class MoltenMDCTest {
         assertThat(MDC.get(KEY)).isEqualTo(VALUE);
     }
 
-    @Test(dataProvider = "onEachOperatorEnabled")
-    public void should_keep_original_MDC_value_even_on_immediate_scheduler(boolean onEachOperatorEnabled) {
+    @ParameterizedTest
+    @MethodSource("onEachOperatorEnabled")
+    void should_keep_original_MDC_value_even_on_immediate_scheduler(boolean onEachOperatorEnabled) {
         MoltenMDC.initialize(onEachOperatorEnabled);
         MDC.put(KEY, VALUE);
         StepVerifier.create(

--- a/molten-health/src/test/java/com/hotels/molten/healthcheck/CircuitBasedFlowMarkerTest.java
+++ b/molten-health/src/test/java/com/hotels/molten/healthcheck/CircuitBasedFlowMarkerTest.java
@@ -19,8 +19,8 @@ package com.hotels.molten.healthcheck;
 import java.time.Duration;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 
 /**
@@ -29,7 +29,7 @@ import reactor.test.StepVerifier;
 public class CircuitBasedFlowMarkerTest {
     private CircuitBasedFlowMarker indicator;
 
-    @BeforeMethod
+    @BeforeEach
     public void initContext() {
         indicator = new CircuitBasedFlowMarker("component", CircuitBreakerConfig.custom()
             .slidingWindow(2, 1, CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)

--- a/molten-health/src/test/java/com/hotels/molten/healthcheck/HealthIndicatorTest.java
+++ b/molten-health/src/test/java/com/hotels/molten/healthcheck/HealthIndicatorTest.java
@@ -18,8 +18,8 @@ package com.hotels.molten.healthcheck;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
@@ -31,7 +31,7 @@ import com.hotels.molten.test.AssertSubscriber;
 public class HealthIndicatorTest {
     private CompositeHealthIndicator composite;
 
-    @BeforeMethod
+    @BeforeEach
     public void setUp() {
         composite = HealthIndicator.composite("test");
     }

--- a/molten-health/src/test/java/com/hotels/molten/healthcheck/resilience4j/HealthIndicatorOverCircuitBreakerTest.java
+++ b/molten-health/src/test/java/com/hotels/molten/healthcheck/resilience4j/HealthIndicatorOverCircuitBreakerTest.java
@@ -24,13 +24,13 @@ import static org.mockito.Mockito.when;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.event.CircuitBreakerOnStateTransitionEvent;
 import io.github.resilience4j.core.EventConsumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.testng.MockitoTestNGListener;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Listeners;
-import org.testng.annotations.Test;
+import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.test.StepVerifier;
 
 import com.hotels.molten.healthcheck.Status;
@@ -38,7 +38,7 @@ import com.hotels.molten.healthcheck.Status;
 /**
  * Unit test for {@link HealthIndicatorOverCircuitBreaker}.
  */
-@Listeners(MockitoTestNGListener.class)
+@ExtendWith(MockitoExtension.class)
 public class HealthIndicatorOverCircuitBreakerTest {
     private static final String A_NAME = "any";
     @Mock
@@ -49,7 +49,7 @@ public class HealthIndicatorOverCircuitBreakerTest {
     private ArgumentCaptor<EventConsumer<CircuitBreakerOnStateTransitionEvent>> eventConsumerCaptor;
     private HealthIndicatorOverCircuitBreaker indicator;
 
-    @BeforeMethod
+    @BeforeEach
     public void setUp() {
         when(circuitBreaker.getEventPublisher()).thenReturn(eventPublisher);
         when(circuitBreaker.getState()).thenReturn(CircuitBreaker.State.CLOSED);
@@ -58,12 +58,12 @@ public class HealthIndicatorOverCircuitBreakerTest {
     }
 
     @Test
-    public void shouldReturnName() {
+    public void should_return_name() {
         assertThat(indicator.name()).isEqualTo(A_NAME);
     }
 
     @Test
-    public void shouldEmitLatestState() {
+    public void should_emit_latest_state() {
         verify(eventPublisher).onStateTransition(eventConsumerCaptor.capture());
         StepVerifier.create(indicator.health().take(2))
             .assertNext(n -> assertThat(n).hasStatus(Status.UP))
@@ -73,7 +73,7 @@ public class HealthIndicatorOverCircuitBreakerTest {
     }
 
     @Test
-    public void shouldHalfOpenStateEmitStruggling() {
+    public void should_half_open_state_emit_struggling() {
         verify(eventPublisher).onStateTransition(eventConsumerCaptor.capture());
         StepVerifier.create(indicator.health().take(4))
             .assertNext(n -> assertThat(n).hasStatus(Status.UP))
@@ -87,7 +87,7 @@ public class HealthIndicatorOverCircuitBreakerTest {
     }
 
     @Test
-    public void shouldHealthBasedOnStateForTheFirstTime() {
+    public void should_health_based_on_state_for_the_first_time() {
         when(circuitBreaker.getState()).thenReturn(CircuitBreaker.State.OPEN);
         indicator = new HealthIndicatorOverCircuitBreaker(circuitBreaker);
         StepVerifier.create(indicator.health().take(1))

--- a/molten-health/src/test/java/com/hotels/molten/healthcheck/snapshot/HealthSnapshotTest.java
+++ b/molten-health/src/test/java/com/hotels/molten/healthcheck/snapshot/HealthSnapshotTest.java
@@ -19,7 +19,7 @@ package com.hotels.molten.healthcheck.snapshot;
 import java.time.Duration;
 import java.util.List;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 

--- a/molten-http-client/src/test/java/com/hotels/molten/http/client/BulkheadingReactiveProxyFactoryTest.java
+++ b/molten-http-client/src/test/java/com/hotels/molten/http/client/BulkheadingReactiveProxyFactoryTest.java
@@ -29,12 +29,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import io.github.resilience4j.bulkhead.BulkheadFullException;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.testng.MockitoTestNGListener;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Listeners;
-import org.testng.annotations.Test;
+import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 import reactor.test.scheduler.VirtualTimeScheduler;
@@ -45,7 +45,7 @@ import com.hotels.molten.test.AssertSubscriber;
 /**
  * Unit test for {@link BulkheadingReactiveProxyFactory}.
  */
-@Listeners(MockitoTestNGListener.class)
+@ExtendWith(MockitoExtension.class)
 public class BulkheadingReactiveProxyFactoryTest {
     private static final AtomicInteger ISO_GRP_IDX = new AtomicInteger();
     private static final int REQUEST_PARAM = 1;
@@ -57,21 +57,21 @@ public class BulkheadingReactiveProxyFactoryTest {
     private VirtualTimeScheduler scheduler;
     private SimpleMeterRegistry meterRegistry;
 
-    @BeforeMethod
-    public void initContext() {
+    @BeforeEach
+    void initContext() {
         scheduler = VirtualTimeScheduler.create();
         VirtualTimeScheduler.set(scheduler);
         meterRegistry = new SimpleMeterRegistry();
     }
 
-    @AfterMethod
-    public void clearContext() {
+    @AfterEach
+    void clearContext() {
         VirtualTimeScheduler.reset();
         MoltenMetrics.setDimensionalMetricsEnabled(false);
     }
 
     @Test
-    public void should_prevent_too_many_concurrent_requests() {
+    void should_prevent_too_many_concurrent_requests() {
         MoltenMetrics.setDimensionalMetricsEnabled(true);
         MoltenMetrics.setGraphiteIdMetricsLabelEnabled(true);
         AtomicInteger callCount = new AtomicInteger();

--- a/molten-http-client/src/test/java/com/hotels/molten/http/client/RetrofitServiceClientConfigurationReporterTest.java
+++ b/molten-http-client/src/test/java/com/hotels/molten/http/client/RetrofitServiceClientConfigurationReporterTest.java
@@ -24,9 +24,9 @@ import java.time.Duration;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.hotels.molten.core.metrics.MoltenMetrics;
 
@@ -38,13 +38,13 @@ public class RetrofitServiceClientConfigurationReporterTest {
     private MeterRegistry meterRegistry;
     private RetrofitServiceClientConfigurationReporter reporter;
 
-    @BeforeMethod
+    @BeforeEach
     public void initContext() {
         meterRegistry = new SimpleMeterRegistry();
         reporter = new RetrofitServiceClientConfigurationReporter(meterRegistry, CLIENT_ID);
     }
 
-    @AfterMethod
+    @AfterEach
     public void clearContext() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
     }

--- a/molten-http-client/src/test/java/com/hotels/molten/http/client/RetryingReactiveProxyFactoryTest.java
+++ b/molten-http-client/src/test/java/com/hotels/molten/http/client/RetryingReactiveProxyFactoryTest.java
@@ -36,13 +36,13 @@ import ch.qos.logback.core.Appender;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.testng.MockitoTestNGListener;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Listeners;
-import org.testng.annotations.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -52,7 +52,7 @@ import com.hotels.molten.core.metrics.MoltenMetrics;
  * Unit test for {@link RetryingReactiveProxyFactory}.
  */
 @Slf4j
-@Listeners(MockitoTestNGListener.class)
+@ExtendWith(MockitoExtension.class)
 public class RetryingReactiveProxyFactoryTest {
     private static final String CLIENT_ID = "clientId";
     private RetryingReactiveProxyFactory proxyFactory;
@@ -63,7 +63,7 @@ public class RetryingReactiveProxyFactoryTest {
     @Mock
     private Appender<ILoggingEvent> appender;
 
-    @BeforeMethod
+    @BeforeEach
     public void initContext() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
         meterRegistry = new SimpleMeterRegistry();
@@ -72,7 +72,7 @@ public class RetryingReactiveProxyFactoryTest {
         callLogger.addAppender(appender);
     }
 
-    @AfterMethod
+    @AfterEach
     public void clearContext() {
         callLogger.detachAppender(appender);
         MoltenMetrics.setDimensionalMetricsEnabled(false);

--- a/molten-http-client/src/test/java/com/hotels/molten/http/client/TlsSocketFactoryConfigFactoryTest.java
+++ b/molten-http-client/src/test/java/com/hotels/molten/http/client/TlsSocketFactoryConfigFactoryTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit test for {@link TlsSocketFactoryConfigFactory}.
@@ -31,19 +31,19 @@ public class TlsSocketFactoryConfigFactoryTest {
     private static final String VALID_PASS = "password";
 
     @Test
-    public void shouldProvideAssembledConfigFromFactories() {
+    void should_provide_assembled_config_from_factories() {
         assertThat(TlsSocketFactoryConfigFactory.createConfig(KEY_STORE_FILE, VALID_PASS)).hasNoNullFieldsOrProperties();
     }
 
     @Test
-    public void shouldThrowExceptionIfCouldNotFindKeyStore() {
+    void should_throw_exception_if_could_not_find_key_store() {
         assertThatThrownBy(() -> TlsSocketFactoryConfigFactory.createConfig("invalidKeyStoreFilePath", VALID_PASS))
             .isExactlyInstanceOf(IllegalStateException.class)
             .hasCauseInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void shouldPropagateExceptionOccursDuringSslSocketFactoryConfigInstantiation() {
+    void should_propagate_exception_occurs_during_ssl_socket_factory_config_instantiation() {
         assertThatThrownBy(() -> TlsSocketFactoryConfigFactory.createConfig(KEY_STORE_FILE, "invalidPass"))
             .isExactlyInstanceOf(IllegalStateException.class)
             .hasCauseInstanceOf(IOException.class);

--- a/molten-http-client/src/test/java/com/hotels/molten/http/client/listener/CollectingDelegatingEventsListenerTest.java
+++ b/molten-http-client/src/test/java/com/hotels/molten/http/client/listener/CollectingDelegatingEventsListenerTest.java
@@ -29,16 +29,16 @@ import com.google.common.collect.ImmutableMultimap;
 import okhttp3.Call;
 import okhttp3.Connection;
 import okhttp3.HttpUrl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.testng.MockitoTestNGListener;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Listeners;
-import org.testng.annotations.Test;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * Test for {@link CollectingDelegatingEventsListener}.
  */
-@Listeners(MockitoTestNGListener.class)
+@ExtendWith(MockitoExtension.class)
 public class CollectingDelegatingEventsListenerTest {
 
     @Mock
@@ -54,7 +54,7 @@ public class CollectingDelegatingEventsListenerTest {
     @Mock
     private Clock clock;
 
-    @BeforeMethod
+    @BeforeEach
     public void init() {
         AtomicLong now = new AtomicLong();
         when(clock.millis()).thenAnswer(ie -> now.getAndAdd(100L));

--- a/molten-http-client/src/test/java/com/hotels/molten/http/client/listener/DurationMetricsReporterHandlerTest.java
+++ b/molten-http-client/src/test/java/com/hotels/molten/http/client/listener/DurationMetricsReporterHandlerTest.java
@@ -25,19 +25,19 @@ import com.google.common.collect.ImmutableMultimap;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import okhttp3.HttpUrl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.testng.MockitoTestNGListener;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Listeners;
-import org.testng.annotations.Test;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.hotels.molten.core.metrics.MoltenMetrics;
 
 /**
  * Test for {@link DurationMetricsReporterHandler}.
  */
-@Listeners(MockitoTestNGListener.class)
+@ExtendWith(MockitoExtension.class)
 public class DurationMetricsReporterHandlerTest {
     private static final String CLIENT_ID = "clientId";
     private MeterRegistry meterRegistry;
@@ -45,13 +45,13 @@ public class DurationMetricsReporterHandlerTest {
     private HttpUrl httpUrl;
     private DurationMetricsReporterHandler handler;
 
-    @BeforeMethod
+    @BeforeEach
     public void init() {
         meterRegistry = new SimpleMeterRegistry();
         handler = new DurationMetricsReporterHandler(meterRegistry, CLIENT_ID);
     }
 
-    @AfterMethod
+    @AfterEach
     public void clearContext() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
     }

--- a/molten-http-client/src/test/java/com/hotels/molten/http/client/listener/HttpMetricsReporterHandlerTest.java
+++ b/molten-http-client/src/test/java/com/hotels/molten/http/client/listener/HttpMetricsReporterHandlerTest.java
@@ -25,19 +25,19 @@ import com.google.common.collect.ImmutableMultimap;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import okhttp3.HttpUrl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.testng.MockitoTestNGListener;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Listeners;
-import org.testng.annotations.Test;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.hotels.molten.core.metrics.MoltenMetrics;
 
 /**
  * Unit test for {@link HttpMetricsReporterHandler}.
  */
-@Listeners(MockitoTestNGListener.class)
+@ExtendWith(MockitoExtension.class)
 public class HttpMetricsReporterHandlerTest {
     private static final String CLIENT_ID = "clientId";
     private MeterRegistry meterRegistry;
@@ -45,13 +45,13 @@ public class HttpMetricsReporterHandlerTest {
     private HttpUrl httpUrl;
     private HttpMetricsReporterHandler handler;
 
-    @BeforeMethod
+    @BeforeEach
     public void init() {
         meterRegistry = new SimpleMeterRegistry();
         handler = new HttpMetricsReporterHandler(meterRegistry, CLIENT_ID);
     }
 
-    @AfterMethod
+    @AfterEach
     public void clearContext() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
     }

--- a/molten-http-client/src/test/java/com/hotels/molten/http/client/listener/LoggingHttpCallMetricsHandlerTest.java
+++ b/molten-http-client/src/test/java/com/hotels/molten/http/client/listener/LoggingHttpCallMetricsHandlerTest.java
@@ -17,7 +17,6 @@
 package com.hotels.molten.http.client.listener;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -27,26 +26,25 @@ import java.net.URI;
 import ch.qos.logback.classic.Logger;
 import com.google.common.collect.ImmutableMultimap;
 import okhttp3.HttpUrl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * Test for {@link LoggingHttpCallMetricsHandler}.
  */
+@ExtendWith(MockitoExtension.class)
 public class LoggingHttpCallMetricsHandlerTest {
 
+    @Mock
     private HttpUrl requestUrl;
+    @Mock
     private Logger logger;
 
-    @BeforeTest
-    public void init() {
-        this.requestUrl = mock(HttpUrl.class);
-        this.logger = mock(Logger.class);
-    }
-
     @Test
-    public void shouldCreateProperEventLog() {
+    public void should_create_proper_event_log() {
         // Given
         var events = ImmutableMultimap.<HttpEvent, Long>builder()
             .put(HttpEvent.CALL_START, 0L)

--- a/molten-http-client/src/test/java/com/hotels/molten/http/client/metrics/ConnectionPoolInstrumenterTest.java
+++ b/molten-http-client/src/test/java/com/hotels/molten/http/client/metrics/ConnectionPoolInstrumenterTest.java
@@ -23,18 +23,18 @@ import static org.mockito.Mockito.when;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import okhttp3.ConnectionPool;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.testng.MockitoTestNGListener;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Listeners;
-import org.testng.annotations.Test;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.hotels.molten.core.metrics.MoltenMetrics;
 
 /**
  * Unit test for {@link ConnectionPoolInstrumenter}.
  */
-@Listeners(MockitoTestNGListener.class)
+@ExtendWith(MockitoExtension.class)
 public class ConnectionPoolInstrumenterTest {
     private static final String CLIENT_ID = "clientId";
     private ConnectionPoolInstrumenter instrumenter;
@@ -42,7 +42,7 @@ public class ConnectionPoolInstrumenterTest {
     @Mock
     private ConnectionPool connectionPool;
 
-    @BeforeMethod
+    @BeforeEach
     public void initContext() {
         meterRegistry = new SimpleMeterRegistry();
         instrumenter = new ConnectionPoolInstrumenter(meterRegistry, CLIENT_ID);

--- a/molten-http-client/src/test/java/com/hotels/molten/http/client/metrics/DispatcherInstrumenterTest.java
+++ b/molten-http-client/src/test/java/com/hotels/molten/http/client/metrics/DispatcherInstrumenterTest.java
@@ -23,18 +23,18 @@ import static org.mockito.Mockito.when;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import okhttp3.Dispatcher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.testng.MockitoTestNGListener;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Listeners;
-import org.testng.annotations.Test;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.hotels.molten.core.metrics.MoltenMetrics;
 
 /**
  * Unit test for {@link DispatcherInstrumenter}.
  */
-@Listeners(MockitoTestNGListener.class)
+@ExtendWith(MockitoExtension.class)
 public class DispatcherInstrumenterTest {
     private static final String CLIENT_ID = "clientId";
     private DispatcherInstrumenter instrumenter;
@@ -42,7 +42,7 @@ public class DispatcherInstrumenterTest {
     @Mock
     private Dispatcher dispatcher;
 
-    @BeforeMethod
+    @BeforeEach
     public void initContext() {
         meterRegistry = new SimpleMeterRegistry();
         instrumenter = new DispatcherInstrumenter(meterRegistry, CLIENT_ID);

--- a/molten-http-client/src/test/java/com/hotels/molten/http/client/metrics/MicrometerHttpClientMetricsRecorderTest.java
+++ b/molten-http-client/src/test/java/com/hotels/molten/http/client/metrics/MicrometerHttpClientMetricsRecorderTest.java
@@ -26,30 +26,29 @@ import java.util.concurrent.TimeUnit;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.mockito.testng.MockitoTestNGListener;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Listeners;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.netty.http.client.HttpClientMetricsRecorder;
 
 import com.hotels.molten.core.metrics.MoltenMetrics;
 
 /**
  * Unit test for {@link MicrometerHttpClientMetricsRecorder}.
  */
-@Listeners(MockitoTestNGListener.class)
 public class MicrometerHttpClientMetricsRecorderTest {
     private static final String CLIENT_ID = "clientId";
-    private MicrometerHttpClientMetricsRecorder recorder;
-    private MeterRegistry meterRegistry;
 
-    @BeforeMethod
+    private MeterRegistry meterRegistry;
+    private HttpClientMetricsRecorder recorder;
+
+    @BeforeEach
     public void initContext() {
         meterRegistry = new SimpleMeterRegistry();
         recorder = new MicrometerHttpClientMetricsRecorder(meterRegistry, CLIENT_ID);
     }
 
-    @AfterMethod
+    @AfterEach
     public void clearContext() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
     }

--- a/molten-http-client/src/test/java/com/hotels/molten/http/client/tracking/MdcBasedMessageGroupIdTrackingHeaderSupplierTest.java
+++ b/molten-http-client/src/test/java/com/hotels/molten/http/client/tracking/MdcBasedMessageGroupIdTrackingHeaderSupplierTest.java
@@ -21,10 +21,10 @@ import static org.hamcrest.Matchers.is;
 
 import java.util.Optional;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.MDC;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 
 import com.hotels.molten.http.client.tracking.RequestTracking.TrackingHeader;
 
@@ -34,20 +34,21 @@ import com.hotels.molten.http.client.tracking.RequestTracking.TrackingHeader;
 public class MdcBasedMessageGroupIdTrackingHeaderSupplierTest {
     private static final String HEADER_NAME = "header name";
     private static final String ID = "id";
+
     private MdcBasedMessageGroupIdTrackingHeaderSupplier provider;
 
-    @BeforeMethod
+    @BeforeEach
     public void initContext() {
         provider = new MdcBasedMessageGroupIdTrackingHeaderSupplier(HEADER_NAME);
     }
 
-    @AfterMethod
+    @AfterEach
     public void tearDownContext() {
         MDC.clear();
     }
 
     @Test
-    public void shouldProvideMessageGroupIdFromMDC() {
+    public void should_provide_message_group_id_from_mdc() {
         MDC.put("messageGroupId", ID);
         MDC.put("requestId", "something else");
 
@@ -55,14 +56,14 @@ public class MdcBasedMessageGroupIdTrackingHeaderSupplierTest {
     }
 
     @Test
-    public void shouldProvideRequestIdFromMDCIfMessageGroupIdIsNotAvailable() {
+    public void should_provide_request_id_from_mdcif_message_group_id_is_not_available() {
         MDC.put("requestId", ID);
 
         assertThat(provider.get(), is(Optional.of(new TrackingHeader(HEADER_NAME, ID))));
     }
 
     @Test
-    public void shouldProvideEmptyIfSessionIdIsNotAvailable() {
+    public void should_provide_empty_if_session_id_is_not_available() {
         assertThat(provider.get(), is(Optional.empty()));
     }
 }

--- a/molten-http-client/src/test/java/com/hotels/molten/http/client/tracking/MdcBasedSessionIdTrackingHeaderSupplierTest.java
+++ b/molten-http-client/src/test/java/com/hotels/molten/http/client/tracking/MdcBasedSessionIdTrackingHeaderSupplierTest.java
@@ -21,10 +21,10 @@ import static org.hamcrest.Matchers.is;
 
 import java.util.Optional;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.MDC;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 
 import com.hotels.molten.http.client.tracking.RequestTracking.TrackingHeader;
 
@@ -34,27 +34,28 @@ import com.hotels.molten.http.client.tracking.RequestTracking.TrackingHeader;
 public class MdcBasedSessionIdTrackingHeaderSupplierTest {
     private static final String HEADER_NAME = "header name";
     private static final String ID = "id";
+
     private MdcBasedSessionIdTrackingHeaderSupplier provider;
 
-    @BeforeMethod
+    @BeforeEach
     public void initContext() {
         provider = new MdcBasedSessionIdTrackingHeaderSupplier(HEADER_NAME);
     }
 
-    @AfterMethod
+    @AfterEach
     public void tearDownContext() {
         MDC.clear();
     }
 
     @Test
-    public void shouldProvideMessageGroupIdFromMDC() {
+    public void should_provide_message_group_id_from_mdc() {
         MDC.put("sessionId", ID);
 
         assertThat(provider.get(), is(Optional.of(new TrackingHeader(HEADER_NAME, ID))));
     }
 
     @Test
-    public void shouldProvideEmptyIfSessionIdIsNotAvailable() {
+    public void should_provide_empty_if_session_id_is_not_available() {
         assertThat(provider.get(), is(Optional.empty()));
     }
 }

--- a/molten-metrics/src/test/java/com/hotels/molten/metrics/InstrumentTest.java
+++ b/molten-metrics/src/test/java/com/hotels/molten/metrics/InstrumentTest.java
@@ -31,9 +31,9 @@ import java.util.function.Supplier;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.assertj.core.api.Assertions;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.hotels.molten.core.metrics.MoltenMetrics;
 
@@ -45,42 +45,42 @@ public class InstrumentTest {
     private InstrumentTestFixture fixture;
     private Instrument.Builder instrumentBuilder;
 
-    @BeforeMethod
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
         fixture = new InstrumentTestFixture();
         instrumentBuilder = Instrument.builder(fixture.getMeterRegistry()).withQualifier("test");
     }
 
-    @AfterMethod
-    public void clearContext() {
+    @AfterEach
+    void clearContext() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
     }
 
     @Test
-    public void shouldReturnSupplierResultIfSuccess() {
+    void should_return_supplier_result_if_success() {
         final String result = "result";
         fixture
-                .when(() -> instrumentBuilder.build().supplier(() -> result).get())
-                .expectResult(result);
+            .when(() -> instrumentBuilder.build().supplier(() -> result).get())
+            .expectResult(result);
     }
 
     @Test
-    public void shouldReturnFunctionResultIfSuccess() {
+    void should_return_function_result_if_success() {
         Function<Integer, Integer> increment = num -> num + 1;
         fixture.when(() -> instrumentBuilder.build().function(increment).apply(1))
-                .expectResult(2);
+            .expectResult(2);
     }
 
     @Test
-    public void shouldReturnCallableResultIfSuccess() {
+    void should_return_callable_result_if_success() {
         final String result = "result";
         fixture.when(() -> instrumentBuilder.build().callable(() -> result).call())
-                .expectResult(result);
+            .expectResult(result);
     }
 
     @Test
-    public void shouldReturnConsumerResultIfSuccess() {
+    void should_return_consumer_result_if_success() {
         List<Integer> list = new ArrayList<>();
         IntConsumer c = list::add;
         Consumer<Integer> consumer = instrumentBuilder.build().consumer(c::accept);
@@ -89,12 +89,12 @@ public class InstrumentTest {
             consumer.accept(2);
             return null;
         })
-                .expectResult(null);
+            .expectResult(null);
         assertThat(list, is(List.of(2)));
     }
 
     @Test
-    public void shouldRunRunnable() {
+    void should_run_runnable() {
         AtomicBoolean called = new AtomicBoolean(false);
         Runnable runnable = instrumentBuilder.build().runnable(() -> called.set(true));
 
@@ -102,12 +102,12 @@ public class InstrumentTest {
             runnable.run();
             return null;
         })
-                .expectResult(null);
+            .expectResult(null);
         assertThat(called.get(), is(true));
     }
 
     @Test
-    public void shouldThrowOriginalExceptionFromRunnable() {
+    void should_throw_original_exception_from_runnable() {
         RuntimeException expectedException = new RuntimeException();
         Runnable runnable = () -> {
             throw expectedException;
@@ -116,42 +116,42 @@ public class InstrumentTest {
             instrumentBuilder.build().runnable(runnable).run();
             return null;
         })
-                .expectThrowNonBusinessException(expectedException);
+            .expectThrowNonBusinessException(expectedException);
     }
 
     @Test
-    public void shouldThrowOriginalExceptionFromFunction() {
+    void should_throw_original_exception_from_function() {
         RuntimeException expectedException = new RuntimeException();
         Function<Integer, Integer> function = num -> {
             throw expectedException;
         };
         fixture
-                .when(() -> instrumentBuilder.build().function(function).apply(1))
-                .expectThrowNonBusinessException(expectedException);
+            .when(() -> instrumentBuilder.build().function(function).apply(1))
+            .expectThrowNonBusinessException(expectedException);
     }
 
     @Test
-    public void shouldThrowOriginalExceptionFromSupplier() {
+    void should_throw_original_exception_from_supplier() {
         RuntimeException expectedException = new RuntimeException();
         Supplier<Integer> supplier = () -> {
             throw expectedException;
         };
         fixture.when(() -> instrumentBuilder.build().supplier(supplier).get())
-                .expectThrowNonBusinessException(expectedException);
+            .expectThrowNonBusinessException(expectedException);
     }
 
     @Test
-    public void shouldThrowOriginalExceptionFromCallable() {
+    void should_throw_original_exception_from_callable() {
         RuntimeException expectedException = new RuntimeException();
         Callable<Integer> callable = () -> {
             throw expectedException;
         };
         fixture.when(() -> instrumentBuilder.build().callable(callable).call())
-                .expectThrowNonBusinessException(expectedException);
+            .expectThrowNonBusinessException(expectedException);
     }
 
     @Test
-    public void shouldThrowOriginalExceptionFromConsumer() {
+    void should_throw_original_exception_from_consumer() {
         RuntimeException expectedException = new RuntimeException();
         Consumer<Integer> consumer = instrumentBuilder.build().consumer(integer -> {
             throw expectedException;
@@ -161,41 +161,41 @@ public class InstrumentTest {
             consumer.accept(2);
             return null;
         })
-                .expectThrowNonBusinessException(expectedException);
+            .expectThrowNonBusinessException(expectedException);
     }
 
     @Test
-    public void shouldFunctionThrowBusinessException() {
+    void should_function_throw_business_exception() {
         RuntimeException expectedException = new RuntimeException();
         Function<Integer, Integer> function = num -> {
             throw expectedException;
         };
         fixture.when(() -> instrumentBuilder.withBusinessExceptionDecisionMaker(e -> true).build().function(function).apply(1))
-                .expectThrowBusinessException(expectedException);
+            .expectThrowBusinessException(expectedException);
     }
 
     @Test
-    public void shouldSupplierThrowBusinessException() {
+    void should_supplier_throw_business_exception() {
         RuntimeException expectedException = new RuntimeException();
         Supplier<Integer> supplier = () -> {
             throw expectedException;
         };
         fixture.when(() -> instrumentBuilder.withBusinessExceptionDecisionMaker(e -> true).build().supplier(supplier).get())
-                .expectThrowBusinessException(expectedException);
+            .expectThrowBusinessException(expectedException);
     }
 
     @Test
-    public void shouldCallableThrowBusinessException() {
+    void should_callable_throw_business_exception() {
         RuntimeException expectedException = new RuntimeException();
         Callable<Integer> callable = () -> {
             throw expectedException;
         };
         fixture.when(() -> instrumentBuilder.withBusinessExceptionDecisionMaker(e -> true).build().callable(callable).call())
-                .expectThrowBusinessException(expectedException);
+            .expectThrowBusinessException(expectedException);
     }
 
     @Test
-    public void shouldConsumerThrowBusinessException() {
+    void should_consumer_throw_business_exception() {
         RuntimeException expectedException = new RuntimeException();
         Consumer<Integer> consumer = instrumentBuilder.withBusinessExceptionDecisionMaker(e -> true).build().consumer(integer -> {
             throw expectedException;
@@ -205,11 +205,11 @@ public class InstrumentTest {
             consumer.accept(2);
             return null;
         })
-                .expectThrowBusinessException(expectedException);
+            .expectThrowBusinessException(expectedException);
     }
 
     @Test
-    public void shouldRunnableThrowBusinessException() {
+    void should_runnable_throw_business_exception() {
         RuntimeException expectedException = new RuntimeException();
         Runnable runnable = instrumentBuilder.withBusinessExceptionDecisionMaker(e -> true).build().runnable(() -> {
             throw expectedException;
@@ -219,11 +219,11 @@ public class InstrumentTest {
             runnable.run();
             return null;
         })
-                .expectThrowBusinessException(expectedException);
+            .expectThrowBusinessException(expectedException);
     }
 
     @Test
-    public void dimensional_metrics_enabled_should_register_labels_for_status() throws Exception {
+    void dimensional_metrics_enabled_should_register_labels_for_status() throws Exception {
         // Given
         MoltenMetrics.setDimensionalMetricsEnabled(true);
         MoltenMetrics.setGraphiteIdMetricsLabelEnabled(true);

--- a/molten-metrics/src/test/java/com/hotels/molten/metrics/InstrumentedFluxOperatorTest.java
+++ b/molten-metrics/src/test/java/com/hotels/molten/metrics/InstrumentedFluxOperatorTest.java
@@ -29,9 +29,9 @@ import io.micrometer.core.instrument.cumulative.CumulativeTimer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Assertions;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 
 import com.hotels.molten.core.metrics.MetricId;
@@ -50,13 +50,13 @@ public class InstrumentedFluxOperatorTest {
     private MeterRegistry meterRegistry;
     private ReactorInstrument reactorInstrument;
 
-    @BeforeMethod
+    @BeforeEach
     public void init() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
         meterRegistry = new SimpleMeterRegistry();
     }
 
-    @AfterMethod
+    @AfterEach
     public void clearContext() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
     }

--- a/molten-metrics/src/test/java/com/hotels/molten/metrics/InstrumentedMonoOperatorTest.java
+++ b/molten-metrics/src/test/java/com/hotels/molten/metrics/InstrumentedMonoOperatorTest.java
@@ -29,9 +29,9 @@ import io.micrometer.core.instrument.cumulative.CumulativeTimer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Assertions;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
 import com.hotels.molten.core.metrics.MetricId;
@@ -50,13 +50,13 @@ public class InstrumentedMonoOperatorTest {
     private MeterRegistry meterRegistry;
     private ReactorInstrument reactorInstrument;
 
-    @BeforeMethod
+    @BeforeEach
     public void init() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
         meterRegistry = new SimpleMeterRegistry();
     }
 
-    @AfterMethod
+    @AfterEach
     public void clearContext() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
     }

--- a/molten-metrics/src/test/java/com/hotels/molten/metrics/resilience/BulkheadInstrumenterTest.java
+++ b/molten-metrics/src/test/java/com/hotels/molten/metrics/resilience/BulkheadInstrumenterTest.java
@@ -28,9 +28,9 @@ import io.github.resilience4j.reactor.bulkhead.operator.BulkheadOperator;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 import reactor.test.scheduler.VirtualTimeScheduler;
@@ -50,19 +50,18 @@ public class BulkheadInstrumenterTest {
     private static final String OPERATION_TAG_VALUE = "op-value";
     private MeterRegistry meterRegistry;
 
-    @BeforeMethod
-    public void initContext() {
+    @BeforeEach
+    void initContext() {
         meterRegistry = new SimpleMeterRegistry();
     }
 
-    @AfterMethod
-    public void clearContext() {
+    @AfterEach
+    void clearContext() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
-    public void should_instrument_bulkhead_with_hierarchical_metrics() {
+    void should_instrument_bulkhead_with_hierarchical_metrics() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
         var instrumenter = BulkheadInstrumenter.builder()
             .meterRegistry(meterRegistry)
@@ -106,9 +105,8 @@ public class BulkheadInstrumenterTest {
         assertThat(rejectedGauge.value()).isEqualTo(1);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
-    public void should_instrument_bulkhead_with_dimensional_metrics() {
+    void should_instrument_bulkhead_with_dimensional_metrics() {
         MoltenMetrics.setDimensionalMetricsEnabled(true);
         MoltenMetrics.setGraphiteIdMetricsLabelEnabled(true);
         var instrumenter = BulkheadInstrumenter.builder()

--- a/molten-metrics/src/test/java/com/hotels/molten/metrics/resilience/CircuitBreakerInstrumenterTest.java
+++ b/molten-metrics/src/test/java/com/hotels/molten/metrics/resilience/CircuitBreakerInstrumenterTest.java
@@ -26,9 +26,9 @@ import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.assertj.core.api.AbstractDoubleAssert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.hotels.molten.core.metrics.MoltenMetrics;
 
@@ -44,18 +44,18 @@ public class CircuitBreakerInstrumenterTest {
     private static final String OPERATION_TAG_VALUE = "op-value";
     private MeterRegistry meterRegistry;
 
-    @BeforeMethod
-    public void initContext() {
+    @BeforeEach
+    void initContext() {
         meterRegistry = new SimpleMeterRegistry();
     }
 
-    @AfterMethod
-    public void clearContext() {
+    @AfterEach
+    void clearContext() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
     }
 
     @Test
-    public void should_instrument_with_hierarchical_metrics() {
+    void should_instrument_with_hierarchical_metrics() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
         // Given
         var circuitBreaker = CircuitBreaker.of("id", CircuitBreakerConfig.custom()
@@ -94,7 +94,7 @@ public class CircuitBreakerInstrumenterTest {
     }
 
     @Test
-    public void should_instrument_with_dimensional_metrics() {
+    void should_instrument_with_dimensional_metrics() {
         MoltenMetrics.setDimensionalMetricsEnabled(true);
         MoltenMetrics.setGraphiteIdMetricsLabelEnabled(true);
         // Given

--- a/molten-platform/pom.xml
+++ b/molten-platform/pom.xml
@@ -548,6 +548,9 @@
           <forkedProcessExitTimeoutInSeconds>30</forkedProcessExitTimeoutInSeconds>
           <forkCount>1</forkCount>
           <reuseForks>true</reuseForks>
+          <argLine>
+            -Djunit.jupiter.displayname.generator.default=org.junit.jupiter.api.DisplayNameGenerator$ReplaceUnderscores
+          </argLine>
         </configuration>
         <dependencies>
           <dependency>

--- a/molten-remote-cache/src/test/java/com/hotels/molten/cache/redis/LettuceEventBasedHealthIndicatorTest.java
+++ b/molten-remote-cache/src/test/java/com/hotels/molten/cache/redis/LettuceEventBasedHealthIndicatorTest.java
@@ -27,11 +27,11 @@ import io.lettuce.core.event.connection.ConnectedEvent;
 import io.lettuce.core.event.connection.DisconnectedEvent;
 import io.lettuce.core.event.connection.ReconnectFailedEvent;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.testng.MockitoTestNGListener;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Listeners;
-import org.testng.annotations.Test;
+import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.EmitterProcessor;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
@@ -44,7 +44,7 @@ import com.hotels.molten.test.AssertSubscriber;
  * Unit test for {@link LettuceEventBasedHealthIndicator}.
  */
 @Slf4j
-@Listeners(MockitoTestNGListener.class)
+@ExtendWith(MockitoExtension.class)
 public class LettuceEventBasedHealthIndicatorTest {
 
     private static final InetSocketAddress LOCAL = new InetSocketAddress("local", 1111);
@@ -55,7 +55,7 @@ public class LettuceEventBasedHealthIndicatorTest {
     private EventBus eventBus;
     private EmitterProcessor<Event> events;
 
-    @BeforeMethod
+    @BeforeEach
     public void setUp() {
         events = EmitterProcessor.create();
         when(eventBus.get()).thenReturn(events);

--- a/molten-remote-cache/src/test/java/com/hotels/molten/cache/redis/ReactiveRemoteRedisCacheTest.java
+++ b/molten-remote-cache/src/test/java/com/hotels/molten/cache/redis/ReactiveRemoteRedisCacheTest.java
@@ -25,13 +25,13 @@ import java.time.Duration;
 
 import io.lettuce.core.cluster.api.reactive.RedisAdvancedClusterReactiveCommands;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.testng.MockitoTestNGListener;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.MDC;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Listeners;
-import org.testng.annotations.Test;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
 import reactor.core.scheduler.Schedulers;
@@ -48,7 +48,7 @@ import com.hotels.molten.trace.test.AbstractTracingTest;
  * Unit test for {@link ReactiveRemoteRedisCache}.
  */
 @Slf4j
-@Listeners(MockitoTestNGListener.class)
+@ExtendWith(MockitoExtension.class)
 public class ReactiveRemoteRedisCacheTest extends AbstractTracingTest {
     private static final String KEY = "key";
     private static final String CACHE_NAME = "cacheName";
@@ -62,14 +62,14 @@ public class ReactiveRemoteRedisCacheTest extends AbstractTracingTest {
     private RetryingRedisConnectionProvider redisConnectionProvider;
     private VirtualTimeScheduler scheduler;
 
-    @BeforeMethod
+    @BeforeEach
     public void initContext() {
         MoltenMDC.initialize();
         scheduler = VirtualTimeScheduler.create();
         VirtualTimeScheduler.set(scheduler);
     }
 
-    @AfterMethod
+    @AfterEach
     public void tearDown() {
         VirtualTimeScheduler.reset();
         MoltenMDC.uninitialize();

--- a/molten-remote-cache/src/test/java/com/hotels/molten/cache/redis/RetryingRedisConnectionProviderTest.java
+++ b/molten-remote-cache/src/test/java/com/hotels/molten/cache/redis/RetryingRedisConnectionProviderTest.java
@@ -26,41 +26,41 @@ import java.util.function.Supplier;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.cluster.api.reactive.RedisAdvancedClusterReactiveCommands;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.testng.MockitoTestNGListener;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Listeners;
-import org.testng.annotations.Test;
+import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 import reactor.test.scheduler.VirtualTimeScheduler;
+
+import com.hotels.molten.cache.NamedCacheKey;
 
 /**
  * Unit test for {@link RetryingRedisConnectionProvider}.
  */
 @Slf4j
-@Listeners(MockitoTestNGListener.class)
+@ExtendWith(MockitoExtension.class)
 public class RetryingRedisConnectionProviderTest {
 
     @Mock
-    private Supplier<StatefulRedisClusterConnection<Object, Object>> connectionSupplier;
+    private Supplier<StatefulRedisClusterConnection<NamedCacheKey<Object>, Object>> connectionSupplier;
     @Mock
-    private StatefulRedisClusterConnection<Object, Object> connection;
+    private StatefulRedisClusterConnection<NamedCacheKey<Object>, Object> connection;
     @Mock
-    private RedisAdvancedClusterReactiveCommands<Object, Object> reactiveCommands;
-    private RetryingRedisConnectionProvider connectionProvider;
-    private VirtualTimeScheduler scheduler;
+    private RedisAdvancedClusterReactiveCommands<NamedCacheKey<Object>, Object> reactiveCommands;
+    @InjectMocks
+    private RetryingRedisConnectionProvider<Object, Object> connectionProvider;
 
-    @BeforeMethod
+    @BeforeEach
     public void initContext() {
-        scheduler = VirtualTimeScheduler.create();
-        VirtualTimeScheduler.set(scheduler);
-        connectionProvider = new RetryingRedisConnectionProvider(connectionSupplier);
         when(reactiveCommands.clusterNodes()).thenReturn(Mono.empty());
     }
 
-    @AfterMethod
+    @AfterEach
     public void tearDown() {
         VirtualTimeScheduler.reset();
     }

--- a/molten-remote-cache/src/test/java/com/hotels/molten/cache/redis/codec/FlatStringKeyCodecTest.java
+++ b/molten-remote-cache/src/test/java/com/hotels/molten/cache/redis/codec/FlatStringKeyCodecTest.java
@@ -17,6 +17,7 @@
 package com.hotels.molten.cache.redis.codec;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -24,9 +25,10 @@ import java.nio.charset.StandardCharsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.hotels.molten.cache.NamedCacheKey;
 
@@ -36,13 +38,12 @@ import com.hotels.molten.cache.NamedCacheKey;
 public class FlatStringKeyCodecTest {
     private FlatStringKeyCodec<Object, Object> codec;
 
-    @BeforeMethod
+    @BeforeEach
     public void initContext() {
         codec = new FlatStringKeyCodec<>();
     }
 
-    @DataProvider(name = "keys")
-    public Object[][] getKeys() {
+    static Object[][] keys() {
         return new Object[][] {
             new Object[] {"key", "key"},
             new Object[] {new ComplexTypeWithFlatKeySupport("top", new ComplexTypeWithFlatKeySupport.Nested(3, "sometext")), "top:3:sometext"},
@@ -54,14 +55,16 @@ public class FlatStringKeyCodecTest {
         };
     }
 
-    @Test(dataProvider = "keys")
-    public void shouldEncodeKeyAsExpected(Object key, String expectedFlatKey) {
+    @ParameterizedTest
+    @MethodSource("keys")
+    void should_encode_key_as_expected(Object key, String expectedFlatKey) {
         ByteBuffer encodedKey = codec.encodeKey(key);
         assertThat(StandardCharsets.UTF_8.decode(encodedKey).toString()).isEqualTo(expectedFlatKey);
     }
 
-    @Test(expectedExceptions = UnsupportedOperationException.class)
-    public void shouldThrowUnsupportedForEncodingValue() {
-        codec.encodeValue(1);
+    @Test
+    void should_throw_unsupported_for_encoding_value() {
+        assertThatThrownBy(() -> codec.encodeValue(1))
+            .isInstanceOf(UnsupportedOperationException.class);
     }
 }

--- a/molten-remote-cache/src/test/java/com/hotels/molten/cache/redis/codec/KryoRedisCodecTest.java
+++ b/molten-remote-cache/src/test/java/com/hotels/molten/cache/redis/codec/KryoRedisCodecTest.java
@@ -23,8 +23,8 @@ import java.nio.ByteBuffer;
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.pool.KryoPool;
 import lombok.extern.slf4j.Slf4j;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit test for {@link KryoRedisCodec}.
@@ -34,14 +34,14 @@ public class KryoRedisCodecTest {
     private KryoRedisCodec<Object, Object> codec;
     private Kryo kryo;
 
-    @BeforeClass
-    public void initContext() {
+    @BeforeEach
+    void initContext() {
         kryo = new Kryo();
         codec = new KryoRedisCodec<>(new KryoPool.Builder(() -> kryo).build());
     }
 
     @Test
-    public void shouldDeserializeWhichWasSerialized() {
+    void should_deserialize_which_was_serialized() {
         ByteBuffer encodedKey = codec.encodeKey("key");
         ComplexType value = new ComplexType("text", new ComplexType.Nested(1, "txt"));
         ByteBuffer encodedValue = codec.encodeValue(value);

--- a/molten-remote-cache/src/test/java/com/hotels/molten/cache/redis/metrics/CommandLatencyMetricsCollectorTest.java
+++ b/molten-remote-cache/src/test/java/com/hotels/molten/cache/redis/metrics/CommandLatencyMetricsCollectorTest.java
@@ -27,18 +27,18 @@ import java.util.concurrent.TimeUnit;
 import io.lettuce.core.protocol.ProtocolKeyword;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.testng.MockitoTestNGListener;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Listeners;
-import org.testng.annotations.Test;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.hotels.molten.core.metrics.MoltenMetrics;
 
 /**
  * Unit test for {@link CommandLatencyMetricsCollector}.
  */
-@Listeners(MockitoTestNGListener.class)
+@ExtendWith(MockitoExtension.class)
 public class CommandLatencyMetricsCollectorTest {
     private static final String QUALIFIER = "qualifier";
     private static final String REMOTE_HOST = "remote.host";
@@ -52,7 +52,7 @@ public class CommandLatencyMetricsCollectorTest {
     @Mock
     private ProtocolKeyword commandType;
 
-    @BeforeMethod
+    @BeforeEach
     public void initContext() {
         meterRegistry = new SimpleMeterRegistry();
     }

--- a/molten-test/src/test/java/com/hotels/molten/test/mockito/ReactiveAnswerTest.java
+++ b/molten-test/src/test/java/com/hotels/molten/test/mockito/ReactiveAnswerTest.java
@@ -16,9 +16,10 @@
 
 package com.hotels.molten.test.mockito;
 
-import static com.hotels.molten.test.mockito.ReactiveAnswer.reactiveMock;
+import static org.mockito.Mockito.mock;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -28,14 +29,25 @@ import reactor.test.StepVerifier;
  */
 public class ReactiveAnswerTest {
 
-    @Test
-    public void shouldSupportMono() {
-        StepVerifier.create(reactiveMock(ReactiveApi.class).getMono()).expectSubscription().expectComplete().verify();
+    private ReactiveApi mock;
+
+    @BeforeEach
+    void initMock() {
+        mock = mock(ReactiveApi.class, new ReactiveAnswer(invocation -> null));
     }
 
     @Test
-    public void shouldSupportFlux() {
-        StepVerifier.create(reactiveMock(ReactiveApi.class).getFlux()).expectSubscription().expectComplete().verify();
+    void should_support_mono() {
+        StepVerifier.create(mock.getMono())
+            .expectSubscription()
+            .verifyComplete();
+    }
+
+    @Test
+    void should_support_flux() {
+        StepVerifier.create(mock.getFlux())
+            .expectSubscription()
+            .verifyComplete();
     }
 
     private interface ReactiveApi {

--- a/molten-trace-test/pom.xml
+++ b/molten-trace-test/pom.xml
@@ -81,6 +81,11 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>compile</scope>

--- a/molten-trace-test/src/main/java/com/hotels/molten/trace/test/AbstractTracingTest.java
+++ b/molten-trace-test/src/main/java/com/hotels/molten/trace/test/AbstractTracingTest.java
@@ -25,6 +25,9 @@ import java.util.List;
 import brave.ScopedSpan;
 import brave.Tracing;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -42,19 +45,22 @@ import com.hotels.molten.trace.MoltenTrace;
 public abstract class AbstractTracingTest {
 
     @BeforeClass
-    public void initTraceContext() {
+    @BeforeAll
+    public static void initTraceContext() {
         MoltenCore.initialize();
         TracingTestSupport.initialize(false);
         MoltenTrace.initialize();
     }
 
     @AfterClass
-    public void tearDownTraceContext() {
+    @AfterAll
+    public static void tearDownTraceContext() {
         MoltenTrace.uninitialize();
         TracingTestSupport.cleanUp();
     }
 
     @BeforeMethod
+    @BeforeEach
     public void clearTraceContext() {
         TracingTestSupport.resetCapturedSpans();
         Tracing current = Tracing.current();

--- a/molten-trace-test/src/test/java/com/hotels/molten/trace/TracerTest.java
+++ b/molten-trace-test/src/test/java/com/hotels/molten/trace/TracerTest.java
@@ -35,7 +35,7 @@ import brave.Tracing;
 import brave.propagation.TraceContext;
 import lombok.extern.slf4j.Slf4j;
 import org.hamcrest.MatcherAssert;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import com.hotels.molten.trace.Tracer.CheckedRunnable;
 import com.hotels.molten.trace.Tracer.CheckedSupplier;
@@ -51,7 +51,7 @@ import com.hotels.molten.trace.test.SpanMatcher;
 public class TracerTest extends AbstractTracingTest {
 
     @Test
-    public void shouldWrapCallToSpan() {
+    public void should_wrap_call_to_span() {
         try (TraceSpan s = Tracer.span("trace").start()) {
             LOG.info("some task");
         }
@@ -60,7 +60,7 @@ public class TracerTest extends AbstractTracingTest {
     }
 
     @Test
-    public void shouldMarkWithError() {
+    public void should_mark_with_error() {
         TraceSpan span = Tracer.span("trace").start();
         try {
             throw new IllegalStateException("not good");
@@ -74,7 +74,7 @@ public class TracerTest extends AbstractTracingTest {
     }
 
     @Test
-    public void shouldNotPutSpanInScopeIfNoop() {
+    public void should_not_put_span_in_scope_if_noop() {
         Tracing.current().setNoop(true);
         try (TraceSpan s = Tracer.span("trace").start()) {
             LOG.info("some task");
@@ -85,7 +85,7 @@ public class TracerTest extends AbstractTracingTest {
     }
 
     @Test
-    public void shouldNotPutSpanInScopeIfDebugOnlyAndDebugIsDisabled() {
+    public void should_not_put_span_in_scope_if_debug_only_and_debug_is_disabled() {
         TraceContext rootContext = TraceContext.newBuilder().traceId(1).spanId(1).debug(false).build();
         Tracing.current().currentTraceContext().maybeScope(rootContext);
         assertThat(Tracing.current().currentTraceContext().get(), is(rootContext));
@@ -98,7 +98,7 @@ public class TracerTest extends AbstractTracingTest {
     }
 
     @Test
-    public void shouldPutSpanInScopeIfDebugOnlyAndDebugIsEnabled() {
+    public void should_put_span_in_scope_if_debug_only_and_debug_is_enabled() {
         TraceContext rootContext = TraceContext.newBuilder().traceId(1).spanId(1).debug(true).build();
         Tracing.current().currentTraceContext().maybeScope(rootContext);
         assertThat(Tracing.current().currentTraceContext().get(), is(rootContext));
@@ -111,14 +111,14 @@ public class TracerTest extends AbstractTracingTest {
     }
 
     @Test
-    public void shouldWrapSupplierExecution() {
+    public void should_wrap_supplier_execution() {
         MatcherAssert.assertThat(Tracer.span("trace").wrap(() -> "result"), is("result"));
         assertThat(recordedSpans(), hasItem(rootSpanWithName("trace")));
         assertThat(Tracing.current().currentTraceContext().get(), is(nullValue()));
     }
 
     @Test
-    public void shouldPropagateSupplierRuntimeException() {
+    public void should_propagate_supplier_runtime_exception() {
         assertThatExceptionOfType(IllegalStateException.class)
             .isThrownBy(() -> Tracer.span("trace").wrap((Supplier<String>) () -> {
                 throw new IllegalStateException("not good");
@@ -128,7 +128,7 @@ public class TracerTest extends AbstractTracingTest {
     }
 
     @Test
-    public void shouldWrapRunnableExecution() {
+    public void should_wrap_runnable_execution() {
         Runnable runnable = mock(Runnable.class);
         Tracer.span("trace").wrap(runnable);
         verify(runnable).run();
@@ -137,7 +137,7 @@ public class TracerTest extends AbstractTracingTest {
     }
 
     @Test
-    public void shouldPropagateRunnableRuntimeException() {
+    public void should_propagate_runnable_runtime_exception() {
         assertThatExceptionOfType(IllegalStateException.class)
             .isThrownBy(() -> Tracer.span("trace").wrap((Runnable) () -> {
                 throw new IllegalStateException("not good");
@@ -147,7 +147,7 @@ public class TracerTest extends AbstractTracingTest {
     }
 
     @Test
-    public void shouldNotYieldAnyErrorIfTracingIsNotInitialized() {
+    public void should_not_yield_any_error_if_tracing_is_not_initialized() {
         try {
             tearDownTraceContext();
             Runnable runnable = mock(Runnable.class);
@@ -159,7 +159,7 @@ public class TracerTest extends AbstractTracingTest {
     }
 
     @Test
-    public void shouldPropagateSupplierException() {
+    public void should_propagate_supplier_exception() {
         assertThatExceptionOfType(Exception.class)
             .isThrownBy(() -> Tracer.span("trace").wrapChecked((CheckedSupplier<String, Exception>) () -> {
                 throw new Exception("not good");
@@ -169,7 +169,7 @@ public class TracerTest extends AbstractTracingTest {
     }
 
     @Test
-    public void shouldPropagateSupplierWithTwoExceptions() {
+    public void should_propagate_supplier_with_two_exceptions() {
         assertThatExceptionOfType(Exception.class)
             .isThrownBy(() -> Tracer.span("trace").wrapChecked((CheckedSupplier2<String, IOException, Exception>) () -> {
                 throw new Exception("not good");
@@ -179,7 +179,7 @@ public class TracerTest extends AbstractTracingTest {
     }
 
     @Test
-    public void shouldPropagateRunnableException() {
+    public void should_propagate_runnable_exception() {
         assertThatExceptionOfType(Exception.class)
             .isThrownBy(() -> Tracer.span("trace").wrapChecked((CheckedRunnable<Exception>) () -> {
                 throw new Exception("not good");
@@ -189,7 +189,7 @@ public class TracerTest extends AbstractTracingTest {
     }
 
     @Test
-    public void shouldPropagateRunnableWithTwoExceptions() {
+    public void should_propagate_runnable_with_two_exceptions() {
         assertThatExceptionOfType(Exception.class)
             .isThrownBy(() -> Tracer.span("trace").wrapChecked((Tracer.CheckedRunnable2<Exception, IOException>) () -> {
                 throw new Exception("not good");


### PR DESCRIPTION
### :pencil: Description
Migrated most of the tests to JUnit 5 which were based on TestNG before.

Exceptions:
- Unit tests depending on `StubJsonServiceServer`. The reason of this is that the vertx based stub server is interfering with the lifecycle of JUnit 5, making the tests failing. I'm planning to replace `StubJsonServiceServer` with Testcontainers based MockServer soon in a next PR, so I kept them as they are for now.
- Unit tests to check if `molten-test` is working with TestNG as well.
- `TestNGTest` which checks if TestNG tests are running.

Other things:
- Made `org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores` the default `DisplayNameGenerator`.
- Changed test case names to sneak_case, like `should_produce_error`.

Benefits are to use the latest, most feature rich and convenient test framework available for running unit and integration tests.

### :link: Related Issues
It's required to migrate all `*ReactiveCacheTest` to JUnit 5 to be able to add `ReactiveCacheContract` to them all. (from #67) It's already done, I just wanted to keep it separated from this PR.
