### PR TITLE
Extended ReactiveCacheContract to all the ReactiveCache tests

### DIFF
--- a/build/suppressions.xml
+++ b/build/suppressions.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0"?>
 <!DOCTYPE suppressions PUBLIC "-//Puppy Crawl//DTD Suppressions 1.1//EN" "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 <suppressions>
-  <suppress checks="FileLength|MethodLength|ClassDataAbstractionCoupling" files="com.hotels.molten.http.client.RetrofitServiceClientBuilder.java" />
-  <suppress checks="FileLength|MethodLength" files="com.hotels.molten.http.client.StubJsonServiceServer.java" />
-  <suppress checks="NoClone" files="com.hotels.molten.http.client.retrofit.ReactorNettyCall.java" />
-  <suppress checks="VisibilityModifier" files="com.hotels.molten.core.common.AbstractNonFusingSubscription.java" />
-  <suppress checks="IllegalInstantiation" files="com.hotels.molten.http.client.HttpException.java" />
+  <suppress checks="FileLength|MethodLength|ClassDataAbstractionCoupling" files="com.hotels.molten.http.client.RetrofitServiceClientBuilder"/>
+  <suppress checks="FileLength|MethodLength" files="com.hotels.molten.http.client.StubJsonServiceServer"/>
+  <suppress checks="NoClone" files="com.hotels.molten.http.client.retrofit.ReactorNettyCall"/>
+  <suppress checks="VisibilityModifier" files="com.hotels.molten.core.common.AbstractNonFusingSubscription"/>
+  <suppress checks="IllegalInstantiation" files="com.hotels.molten.http.client.HttpException"/>
+  <suppress checks="FinalClass" files="com.hotels.molten.cache.ReactiveReloadingCache"/>
 </suppressions>

--- a/build/suppressions_defaults.xml
+++ b/build/suppressions_defaults.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE suppressions PUBLIC "-//Puppy Crawl//DTD Suppressions 1.1//EN" "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 <suppressions>
   <!-- relax rules in unit tests, we need less docs and magic numbers are commonplace in tests -->
-  <suppress checks="JavadocMethod|MissingJavadocMethod|JavadocType|MissingJavadocType|MagicNumber|ParameterNumber|MethodCount|ClassDataAbstractionCoupling|ClassFanOutComplexity|MultipleStringLiterals|VisibilityModifier|IllegalInstantiation|IllegalThrows|FileLength|MethodLength" files=".*Mock.*java$|.*Test\.java$" />
+  <suppress checks="JavadocMethod|MissingJavadocMethod|JavadocType|MissingJavadocType|MagicNumber|ParameterNumber|MethodCount|ClassDataAbstractionCoupling|ClassFanOutComplexity|MultipleStringLiterals|VisibilityModifier|IllegalInstantiation|IllegalThrows|FileLength|MethodLength" files=".*Mock.*java$|.*Test\.java$|.*TestContract\.java$" />
   <!-- relax rules in configuration, we need less docs, more methods and params, and magic numbers are commonplace in configuration -->
   <suppress checks="JavadocMethod|MissingJavadocMethod|JavadocType|MissingJavadocType|MagicNumber|ParameterNumber|MethodCount|ClassDataAbstractionCoupling|ClassFanOutComplexity" files=".*Configuration\.java$" />
   <suppress id="Constant_AN" files=".*(?&lt;!(Test\.java))$"/>

--- a/molten-bom/pom.xml
+++ b/molten-bom/pom.xml
@@ -124,6 +124,14 @@
         <version>${project.version}</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>com.expediagroup.molten</groupId>
+        <artifactId>molten-cache</artifactId>
+        <version>${project.version}</version>
+        <classifier>test-contract</classifier>
+        <type>test-jar</type>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>

--- a/molten-cache/pom.xml
+++ b/molten-cache/pom.xml
@@ -63,4 +63,29 @@
       <artifactId>molten-test</artifactId>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>package-contract</id>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+            <configuration>
+              <classifier>test-contract</classifier>
+              <includes>
+                <!-- only contracts and their inner classes -->
+                <include>**/*TestContract.class</include>
+                <include>**/*TestContract$*.class</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/molten-cache/readme.md
+++ b/molten-cache/readme.md
@@ -112,3 +112,18 @@ If you need to have bulkhead then you can wrap the inner or outer cache in [Resi
 ```java
 ReactiveCache<Integer, List<String>> resilientCache = new ResilientSharedReactiveCache<>(nonResilientCache, "cacheName", maxConcurrency, metricRegistry);
 ```
+
+## Extensibility
+
+To create and verify custom implementations of `ReactiveCache` even more easily,
+the following test jar is exposed to add `ReactiveCacheContract` to the JUnit 5 based unit tests of your custom caches.
+
+```xml
+<dependency>
+    <groupId>com.expediagroup.molten</groupId>
+    <artifactId>molten-cache</artifactId>
+    <classifier>test-contract</classifier>
+    <type>test-jar</type>
+    <scope>test</scope>
+</dependency>
+```

--- a/molten-cache/src/main/java/com/hotels/molten/cache/ReactiveCache.java
+++ b/molten-cache/src/main/java/com/hotels/molten/cache/ReactiveCache.java
@@ -70,15 +70,13 @@ public interface ReactiveCache<K, V> {
      *
      * <p>Useful for negative cache implementations.</p>
      *
-     * @param key the cache key
-     * @param valueToConverter transforming the non-cached value to be storable, should not return null
+     * @param key                the cache key
+     * @param valueToConverter   transforming the non-cached value to be storable, should not return null
      * @param valueFromConverter transforming the cached value
-     * @param <U> type of the exposed value
+     * @param <U>                type of the exposed value
      * @return a function
      */
-    default <U> Function<Mono<U>, Mono<U>> cachingWith(K key,
-                                                       Function<U, V> valueToConverter,
-                                                       Function<V, U> valueFromConverter) {
+    default <U> Function<Mono<U>, Mono<U>> cachingWith(K key, Function<U, V> valueToConverter, Function<V, U> valueFromConverter) {
         return nonCachedMono -> get(key)
             .switchIfEmpty(nonCachedMono
                 .map(valueToConverter)

--- a/molten-cache/src/main/java/com/hotels/molten/cache/ReactiveReloadingCache.java
+++ b/molten-cache/src/main/java/com/hotels/molten/cache/ReactiveReloadingCache.java
@@ -49,7 +49,7 @@ import com.hotels.molten.core.metrics.MetricId;
  * @param <CACHED_VALUE> the type of cached value
  */
 @Slf4j
-public final class ReactiveReloadingCache<CONTEXT, VALUE, CACHE_KEY, CACHED_VALUE> implements ReactiveCache<CONTEXT, VALUE> {
+public class ReactiveReloadingCache<CONTEXT, VALUE, CACHE_KEY, CACHED_VALUE> implements ReactiveCache<CONTEXT, VALUE> {
     private final ReactiveCache<CACHE_KEY, TimestampedValue<CACHED_VALUE>> delegate;
     private final Duration timeToRefresh;
     private final Clock clock;

--- a/molten-cache/src/test/java/com/hotels/molten/cache/NamedReactiveCacheTest.java
+++ b/molten-cache/src/test/java/com/hotels/molten/cache/NamedReactiveCacheTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -34,7 +35,7 @@ import reactor.test.StepVerifier;
  * Unit test for {@link NamedReactiveCache}.
  */
 @ExtendWith(MockitoExtension.class)
-public class NamedReactiveCacheTest {
+public class NamedReactiveCacheTest implements ReactiveCacheTestContract {
     private static final int KEY = 1;
     private static final String VALUE = "one";
     private static final String CACHENAME = "cachename";
@@ -43,6 +44,11 @@ public class NamedReactiveCacheTest {
     @Mock
     private ReactiveCache<NamedCacheKey<Integer>, CachedValue<String>> cache;
     private NamedReactiveCache<Integer, String> namedReactiveCache;
+
+    @Override
+    public <T> ReactiveCache<Integer, T> createCacheForContractTest() {
+        return new NamedReactiveCache<>(new ReactiveMapCache<>(new ConcurrentHashMap<>()), CACHENAME, TTL);
+    }
 
     @BeforeEach
     public void initContext() {

--- a/molten-cache/src/test/java/com/hotels/molten/cache/ReactiveCacheTestContract.java
+++ b/molten-cache/src/test/java/com/hotels/molten/cache/ReactiveCacheTestContract.java
@@ -16,6 +16,8 @@
 
 package com.hotels.molten.cache;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -28,7 +30,7 @@ import reactor.test.StepVerifier;
 /**
  * {@code ReactiveCache} contract to test the expected behaviours.
  */
-public interface ReactiveCacheContract {
+public interface ReactiveCacheTestContract {
 
     String VALUE = "one";
     int KEY = 1;
@@ -73,13 +75,15 @@ public interface ReactiveCacheContract {
 
     @Test
     default void should_not_fail_if_there_are_no_emitted_items() {
-        ReactiveCache<Integer, String> reactiveCache = createCacheForContractTest();
+        ReactiveCache<Integer, String> reactiveCache = spy(createCacheForContractTest());
         Mono.<String>empty()
             .as(reactiveCache.cachingWith(KEY))
             .as(StepVerifier::create)
             .expectSubscription()
             .thenRequest(1)
             .verifyComplete();
+
+        verify(reactiveCache, never()).put(any(), any());
     }
 
     @Test

--- a/molten-cache/src/test/java/com/hotels/molten/cache/ReactiveCaffeineCacheTest.java
+++ b/molten-cache/src/test/java/com/hotels/molten/cache/ReactiveCaffeineCacheTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -33,13 +34,18 @@ import reactor.test.StepVerifier;
  * Unit test for {@link ReactiveCaffeineCache}.
  */
 @ExtendWith(MockitoExtension.class)
-public class ReactiveCaffeineCacheTest {
+public class ReactiveCaffeineCacheTest implements ReactiveCacheTestContract {
     private static final String VALUE = "one";
     private static final int KEY = 1;
     @Mock
     private Cache<Integer, String> cache;
     @InjectMocks
     private ReactiveCaffeineCache<Integer, String> reactiveCache;
+
+    @Override
+    public <T> ReactiveCache<Integer, T> createCacheForContractTest() {
+        return new ReactiveCaffeineCache<>(Caffeine.newBuilder().build());
+    }
 
     @Test
     public void should_delegate_get_lazily() {

--- a/molten-cache/src/test/java/com/hotels/molten/cache/ReactiveGuavaCacheTest.java
+++ b/molten-cache/src/test/java/com/hotels/molten/cache/ReactiveGuavaCacheTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -33,13 +34,18 @@ import reactor.test.StepVerifier;
  * Unit test for {@link ReactiveGuavaCache}.
  */
 @ExtendWith(MockitoExtension.class)
-public class ReactiveGuavaCacheTest {
+public class ReactiveGuavaCacheTest implements ReactiveCacheTestContract {
     private static final String VALUE = "one";
     private static final int KEY = 1;
     @Mock
     private Cache<Integer, String> cache;
     @InjectMocks
     private ReactiveGuavaCache<Integer, String> reactiveCache;
+
+    @Override
+    public <T> ReactiveCache<Integer, T> createCacheForContractTest() {
+        return new ReactiveGuavaCache<>(CacheBuilder.newBuilder().build());
+    }
 
     @Test
     public void should_delegate_get_lazily() {

--- a/molten-cache/src/test/java/com/hotels/molten/cache/ReactiveMapCacheTest.java
+++ b/molten-cache/src/test/java/com/hotels/molten/cache/ReactiveMapCacheTest.java
@@ -35,7 +35,7 @@ import reactor.test.StepVerifier;
  * Unit test for {@link ReactiveMapCache}.
  */
 @ExtendWith(MockitoExtension.class)
-class ReactiveMapCacheTest implements ReactiveCacheContract {
+class ReactiveMapCacheTest implements ReactiveCacheTestContract {
     private static final String VALUE = "one";
     private static final int KEY = 1;
     @Mock

--- a/molten-cache/src/test/java/com/hotels/molten/cache/metrics/InstrumentedReactiveCacheTest.java
+++ b/molten-cache/src/test/java/com/hotels/molten/cache/metrics/InstrumentedReactiveCacheTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.MockClock;
@@ -35,18 +36,24 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import com.hotels.molten.cache.ReactiveCache;
+import com.hotels.molten.cache.ReactiveCacheTestContract;
 import com.hotels.molten.cache.ReactiveMapCache;
 import com.hotels.molten.core.metrics.MoltenMetrics;
 
 /**
  * Unit test for {@link InstrumentedReactiveCache}.
  */
-public class InstrumentedReactiveCacheTest {
+public class InstrumentedReactiveCacheTest implements ReactiveCacheTestContract {
     private static final String QUALIFIER = "qualifier";
     private static final String CACHE_NAME = "cache_name";
     private static final String REACTIVE_CACHE = "reactive-cache";
     private ReactiveCache<String, String> cache;
     private MeterRegistry meterRegistry;
+
+    @Override
+    public <T> ReactiveCache<Integer, T> createCacheForContractTest() {
+        return new InstrumentedReactiveCache<>(new ReactiveMapCache<>(new ConcurrentHashMap<>()), meterRegistry, CACHE_NAME, QUALIFIER);
+    }
 
     @BeforeEach
     public void initContext() {

--- a/molten-remote-cache/pom.xml
+++ b/molten-remote-cache/pom.xml
@@ -73,6 +73,13 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>com.expediagroup.molten</groupId>
+      <artifactId>molten-cache</artifactId>
+      <classifier>test-contract</classifier>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
       <version>${testcontainers.version}</version>

--- a/molten-remote-cache/src/main/java/com/hotels/molten/cache/redis/ReactiveRemoteRedisCache.java
+++ b/molten-remote-cache/src/main/java/com/hotels/molten/cache/redis/ReactiveRemoteRedisCache.java
@@ -35,7 +35,6 @@ import com.hotels.molten.core.MoltenCore;
  * @param <K> the type of key
  * @param <V> the type of value
  */
-@SuppressWarnings("unchecked")
 @Slf4j
 public class ReactiveRemoteRedisCache<K, V> implements ReactiveCache<NamedCacheKey<K>, CachedValue<V>> {
     private volatile Mono<RedisAdvancedClusterReactiveCommands<NamedCacheKey<K>, V>> reactive = Mono.error(new IllegalStateException("Couldn't acquire a connection yet."));


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/ExpediaGroup/molten/blob/master/CONTRIBUTING.md
-->

### :pencil: Description

As the title says, the PR extends `ReactiveCacheContract` to all the `ReactiveCache` unit tests.

### :link: Related Issues

Fulfills my promise on #67.