### PR TITLE
Add Bulkhead and groupId to FanOutRequestCollapser 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Added `FanOutRequestCollapser.Builder#withGroupId`, so two instance can be differentiated when observing the logs.
-- Added `FanOutRequestCollapser.Builder#withBatchMaxConcurrencyWaitTime` to set the max wait time for a full bulkhead to free up before making the next call failed.
+- Added `FanOutRequestCollapser.Builder#withBatchMaxConcurrencyWaitTime` to set the maximum time to wait for executing
+  a prepared batch call if there are already max concurrency batches running.
 ### Changed
 - Made `FanOutRequestCollapser#maxConcurrency` limit forced by `Bulkhead` instead of the concurrency of `flatMap`,
   which killed the whole collapser instead of that single call over the limit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `FanOutRequestCollapser.Builder#withGroupId`, so two instance can be differentiated when observing the logs.
+- Added `FanOutRequestCollapser.Builder#withBatchMaxConcurrencyWaitTime` to set the max wait time for a full bulkhead to free up before making the next call failed.
+### Changed
+- Made `FanOutRequestCollapser#maxConcurrency` limit forced by `Bulkhead` instead of the concurrency of `flatMap`,
+  which killed the whole collapser instead of that single call over the limit.
+- Dropped support of reactor-core below 3.4.0, by using the new `Sinks` api.
 
 ## [1.1.3]
 ### Changed
 - Migrated most of the unit tests to JUnit 5.
-- Extended testing of ReactiveCache implementations.
+- Extended testing of `ReactiveCache` implementations.
 
 ## [1.1.2]
 ### Added

--- a/molten-core/pom.xml
+++ b/molten-core/pom.xml
@@ -39,6 +39,18 @@
       <artifactId>resilience4j-circuitbreaker</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.github.resilience4j</groupId>
+      <artifactId>resilience4j-bulkhead</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.github.resilience4j</groupId>
+      <artifactId>resilience4j-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.github.resilience4j</groupId>
+      <artifactId>resilience4j-reactor</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.expediagroup.molten</groupId>
       <artifactId>molten-test</artifactId>
     </dependency>

--- a/molten-core/src/main/java/com/hotels/molten/core/collapser/FanOutRequestCollapser.java
+++ b/molten-core/src/main/java/com/hotels/molten/core/collapser/FanOutRequestCollapser.java
@@ -407,11 +407,13 @@ public final class FanOutRequestCollapser<CONTEXT, VALUE> implements Function<CO
 
 
         /**
-         * Sets the maximum concurrency to fire batch calls.
+         * Sets the maximum concurrency to fire batch calls.<br>
+         * If reached, new batch calls will fail with {@link io.github.resilience4j.bulkhead.BulkheadFullException}.
          * By default it is same as the number of available processors.
          *
          * @param maxConcurrency the maximum concurrency for batch calls
          * @return this builder instance
+         * @see #withBatchMaxConcurrencyWaitTime(Duration)
          */
         public Builder<C, V> withBatchMaxConcurrency(int maxConcurrency) {
             checkArgument(maxConcurrency > 0, "Max concurrency should be positive");
@@ -420,8 +422,9 @@ public final class FanOutRequestCollapser<CONTEXT, VALUE> implements Function<CO
         }
 
         /**
-         * Sets the maximum time to wait for a prepared batch call if {@link #withBatchMaxConcurrency(int) max concurrency} is already fulfilled.
-         * By default it's zero.
+         * Sets the maximum time to wait for executing a prepared batch call if there are already {@link #withBatchMaxConcurrency(int) max concurrency} batches running.<br>
+         * If the wait time expires and the prepared batch call couldn't be started, {@link io.github.resilience4j.bulkhead.BulkheadFullException} is thrown.
+         * By default it's {@link Duration#ZERO}, failing fast if the {@link #withBatchMaxConcurrency(int) max concurrency} limit is reached.
          *
          * @param maximumWaitTime the maximum time to wait
          * @return this builder instance

--- a/molten-core/src/test/java/com/hotels/molten/core/collapser/FanOutRequestCollapserTest.java
+++ b/molten-core/src/test/java/com/hotels/molten/core/collapser/FanOutRequestCollapserTest.java
@@ -430,6 +430,7 @@ public class FanOutRequestCollapserTest {
             }
         });
     }
+
     @Test
     void should_complete_for_not_matched_contexts() {
         collapsedProvider = createCollapserBase().build();
@@ -523,6 +524,7 @@ public class FanOutRequestCollapserTest {
             });
 
         Flux.range(1, 100).flatMap(i -> collapsedProvider.apply(i))
+            .ignoreElements() // doesn't matter is some elements are emitted successfully
             .as(StepVerifier::create)
             .verifyErrorSatisfies(e -> assertThat(e)
                 .isInstanceOf(BulkheadFullException.class)
@@ -537,7 +539,7 @@ public class FanOutRequestCollapserTest {
             .withBatchSize(5)
             .withBatchScheduler(Schedulers.parallel())
             .withBatchMaxConcurrency(2)
-            .withBatchMaxConcurrencyWaitTime(Duration.ofMillis(140))
+            .withBatchMaxConcurrencyWaitTime(Duration.ofMillis(160))
             .withEmitScheduler(Schedulers.immediate())
             .build();
         //the throughput will be 10 ids per seconds (batch of 5 * parallelism 2) at 1 sec delayed execution
@@ -584,6 +586,7 @@ public class FanOutRequestCollapserTest {
             });
 
         Flux.range(1, 100).flatMap(i -> collapsedProvider.apply(i))
+            .ignoreElements() // doesn't matter is some elements are emitted successfully
             .as(StepVerifier::create)
             .verifyErrorSatisfies(e -> assertThat(e)
                 .isInstanceOf(BulkheadFullException.class)
@@ -594,11 +597,10 @@ public class FanOutRequestCollapserTest {
     void should_not_execute_more_things_in_parallel_with_delay_but_wait_for_it() {
         collapsedProvider = createCollapserBase()
             .withScheduler(Schedulers.parallel())
-            .withMaximumWaitTime(Duration.ofMillis(200))
             .withBatchSize(5)
             .withBatchScheduler(Schedulers.parallel())
             .withBatchMaxConcurrency(2)
-            .withBatchMaxConcurrencyWaitTime(Duration.ofMillis(140))
+            .withBatchMaxConcurrencyWaitTime(Duration.ofMillis(160))
             .withEmitScheduler(Schedulers.immediate())
             .build();
         //the throughput will be 10 ids per seconds (batch of 5 * parallelism 2) at 1 sec delayed execution

--- a/molten-core/src/test/java/com/hotels/molten/core/collapser/FanOutRequestCollapserTest.java
+++ b/molten-core/src/test/java/com/hotels/molten/core/collapser/FanOutRequestCollapserTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 
+import io.github.resilience4j.bulkhead.BulkheadFullException;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.Tag;
@@ -52,7 +53,6 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -61,6 +61,7 @@ import org.slf4j.MDC;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
+import reactor.test.StepVerifier;
 import reactor.test.scheduler.VirtualTimeScheduler;
 
 import com.hotels.molten.core.MoltenCore;
@@ -112,10 +113,9 @@ public class FanOutRequestCollapserTest {
         batchScheduler = VirtualTimeScheduler.create();
         delayScheduler = VirtualTimeScheduler.create();
         emitScheduler = VirtualTimeScheduler.create();
-        collapsedProvider = createCollapser();
     }
 
-    private FanOutRequestCollapser<Integer, String> createCollapser() {
+    private FanOutRequestCollapser.Builder<Integer, String> createCollapserBase() {
         return FanOutRequestCollapser.collapseCallsOver(bulkProvider)
             .withContextValueMatcher((ctx, value) -> ctx.equals(Integer.parseInt(value)))
             .withScheduler(scheduler)
@@ -123,8 +123,7 @@ public class FanOutRequestCollapserTest {
             .withMaximumWaitTime(Duration.ofMillis(100))
             .withBatchSize(2)
             .withBatchScheduler(batchScheduler)
-            .withMetrics(meterRegistry, MetricId.builder().name(METRICS_QUALIFIER).hierarchicalName(HIERARCHICAL_METRICS_QUALIFIER).tag(Tag.of(TAG_KEY, TAG_VALUE)).build())
-            .build();
+            .withMetrics(meterRegistry, MetricId.builder().name(METRICS_QUALIFIER).hierarchicalName(HIERARCHICAL_METRICS_QUALIFIER).tag(Tag.of(TAG_KEY, TAG_VALUE)).build());
     }
 
     @AfterEach
@@ -136,6 +135,7 @@ public class FanOutRequestCollapserTest {
 
     @Test
     void should_collapse_requests_to_batches() {
+        collapsedProvider = createCollapserBase().build();
         when(bulkProvider.apply((List<Integer>) argThat(contains(CONTEXT_A, CONTEXT_B))))
             .thenAnswer(ie -> {
                 LOG.info("bulk with {}", ie.getArguments());
@@ -164,6 +164,7 @@ public class FanOutRequestCollapserTest {
     @Test
     void should_handle_hierarchical_metrics() {
         MoltenMetrics.setDimensionalMetricsEnabled(false);
+        collapsedProvider = createCollapserBase().build();
         pendingHistogram = hierarchicalMetric("item.pending").summary();
         batchSizeHistogram = hierarchicalMetric("batch.size").summary();
         delayTimer = hierarchicalMetric("item.delay").timer();
@@ -223,7 +224,7 @@ public class FanOutRequestCollapserTest {
     void should_handle_dimensional_metrics() {
         MoltenMetrics.setDimensionalMetricsEnabled(true);
         MoltenMetrics.setGraphiteIdMetricsLabelEnabled(false);
-        collapsedProvider = createCollapser(); // we need to recreate the collapser here to have the above settings take effect
+        collapsedProvider = createCollapserBase().build();
         pendingHistogram = dimensionalMetric("pending").summary();
         batchSizeHistogram = dimensionalMetric("batch_size").summary();
         delayTimer = dimensionalMetric("item_delay").timer();
@@ -282,6 +283,7 @@ public class FanOutRequestCollapserTest {
 
     @Test
     void should_wait_only_maximum_time_for_calls_before_delegating() {
+        collapsedProvider = createCollapserBase().build();
         when(bulkProvider.apply((List<Integer>) argThat(contains(CONTEXT_A))))
             .thenReturn(Mono.just(List.of(RESULT_A)));
 
@@ -297,6 +299,7 @@ public class FanOutRequestCollapserTest {
 
     @Test
     void should_ignore_empty_batch() {
+        collapsedProvider = createCollapserBase().build();
         when(bulkProvider.apply((List<Integer>) argThat(contains(CONTEXT_A))))
             .thenReturn(Mono.just(List.of(RESULT_A)));
 
@@ -317,6 +320,7 @@ public class FanOutRequestCollapserTest {
 
     @Test
     void should_propagate_bulk_load_error_to_each_value() {
+        collapsedProvider = createCollapserBase().build();
         // 2 contexts, bulk error => 2 onError
         IllegalStateException exception = new IllegalStateException("expected error");
         when(bulkProvider.apply((List<Integer>) argThat(contains(CONTEXT_A, CONTEXT_B))))
@@ -336,6 +340,7 @@ public class FanOutRequestCollapserTest {
 
     @Test
     void should_continue_collapsing_after_load_error() {
+        collapsedProvider = createCollapserBase().build();
         IllegalStateException exception = new IllegalStateException("expected error");
         when(bulkProvider.apply((List<Integer>) argThat(containsInAnyOrder(CONTEXT_A, CONTEXT_B))))
             .thenReturn(Mono.error(exception))
@@ -387,15 +392,13 @@ public class FanOutRequestCollapserTest {
             }
             return ret;
         });
-        collapsedProvider = FanOutRequestCollapser.collapseCallsOver(bulkProvider)
-            .withContextValueMatcher((ctx, value) -> ctx.equals(Integer.parseInt(value)))
+        collapsedProvider = createCollapserBase()
             .withMaximumWaitTime(Duration.ofMillis(maxWaitTimeForBatch))
             .withBatchSize(batchSize)
             .withScheduler(Schedulers.parallel())
             .withBatchScheduler(Schedulers.immediate())
             .withBatchMaxConcurrency(maxConcurrency)
             .withEmitScheduler(Schedulers.immediate())
-            .withMetrics(meterRegistry, MetricId.builder().name("metrics").hierarchicalName("metrics").build())
             .build();
         RequestCollapser<Integer, String> requestCollapser = RequestCollapser.builder(collapsedProvider)
             .withScheduler(Schedulers.immediate())
@@ -429,6 +432,7 @@ public class FanOutRequestCollapserTest {
     }
     @Test
     void should_complete_for_not_matched_contexts() {
+        collapsedProvider = createCollapserBase().build();
         // 2 contexts, 1 value => 1 onSuccess, 1 onComplete
         when(bulkProvider.apply((List<Integer>) argThat(contains(CONTEXT_A, CONTEXT_B))))
             .thenReturn(Mono.delay(Duration.ofMillis(50), delayScheduler).map(i -> List.of(RESULT_B)));
@@ -453,6 +457,7 @@ public class FanOutRequestCollapserTest {
 
     @Test
     void should_complete_for_values_where_match_failed() {
+        collapsedProvider = createCollapserBase().build();
         // 2 contexts, 2 values, 1 match fails => 1 onSuccess, 1 onComplete + log
         when(bulkProvider.apply((List<Integer>) argThat(contains(CONTEXT_A, CONTEXT_B))))
             .thenReturn(Mono.delay(Duration.ofMillis(50), delayScheduler).map(i -> List.of(RESULT_B, "a")));
@@ -475,6 +480,7 @@ public class FanOutRequestCollapserTest {
 
     @Test
     void should_be_able_to_shutdown_gracefully() {
+        collapsedProvider = createCollapserBase().build();
         lenient().when(bulkProvider.apply((List<Integer>) argThat(contains(CONTEXT_A, CONTEXT_B))))
             .thenReturn(Mono.just(List.of(RESULT_A)));
 
@@ -493,22 +499,20 @@ public class FanOutRequestCollapserTest {
     }
 
     @Test
-    @Disabled
-    void should_not_execute_more_things_in_parallel() throws InterruptedException {
-        collapsedProvider = FanOutRequestCollapser.collapseCallsOver(bulkProvider)
-            .withContextValueMatcher((ctx, value) -> ctx.equals(Integer.parseInt(value)))
+    void should_not_execute_more_things_in_parallel() {
+        collapsedProvider = createCollapserBase()
             .withScheduler(Schedulers.parallel())
             .withMaximumWaitTime(Duration.ofMillis(200))
             .withBatchSize(5)
             .withBatchScheduler(Schedulers.parallel())
             .withBatchMaxConcurrency(2)
-            .withMetrics(meterRegistry, MetricId.builder().name("metrics").build())
+            .withEmitScheduler(Schedulers.immediate())
             .build();
         //the throughput will be 10 ids per seconds (batch of 5 * parallelism 2) at 1 sec delayed execution
 
         when(bulkProvider.apply(anyList()))
-            .thenAnswer(ia -> {
-                List<Integer> params = (List<Integer>) ia.getArguments()[0];
+            .thenAnswer(invocation -> {
+                List<Integer> params = invocation.getArgument(0);
                 LOG.debug("Returning delayed batched items for {}", params);
                 Thread.sleep(1000);
                 return Flux.fromIterable(params)
@@ -517,19 +521,52 @@ public class FanOutRequestCollapserTest {
                     .doOnSuccess(b -> LOG.debug("Emitting batched items {}", b));
             });
 
-        Flux.range(1, 100).flatMap(i -> collapsedProvider.apply(i)).blockLast();
+        Flux.range(1, 100).flatMap(i -> collapsedProvider.apply(i))
+            .as(StepVerifier::create)
+            .verifyErrorSatisfies(e -> assertThat(e)
+                .isInstanceOf(BulkheadFullException.class)
+                .hasMessageContaining("Bulkhead 'fan out bulkhead' is full"));
     }
 
     @Test
-    @Disabled
-    void should_not_execute_more_things_in_parallel_with_delay() throws InterruptedException {
-        collapsedProvider = FanOutRequestCollapser.collapseCallsOver(bulkProvider)
-            .withContextValueMatcher((ctx, value) -> ctx.equals(Integer.parseInt(value)))
+    void should_not_execute_more_things_in_parallel_but_wait_for_it() {
+        collapsedProvider = createCollapserBase()
             .withScheduler(Schedulers.parallel())
             .withMaximumWaitTime(Duration.ofMillis(200))
             .withBatchSize(5)
             .withBatchScheduler(Schedulers.parallel())
-            .withMetrics(meterRegistry, MetricId.builder().name("metrics").build())
+            .withBatchMaxConcurrency(2)
+            .withBatchMaxConcurrencyWaitTime(Duration.ofMillis(140))
+            .withEmitScheduler(Schedulers.immediate())
+            .build();
+        //the throughput will be 10 ids per seconds (batch of 5 * parallelism 2) at 1 sec delayed execution
+
+        when(bulkProvider.apply(anyList()))
+            .thenAnswer(invocation -> {
+                List<Integer> params = invocation.getArgument(0);
+                LOG.debug("Returning delayed batched items for {}", params);
+                Thread.sleep(100);
+                return Flux.fromIterable(params)
+                    .map(Object::toString)
+                    .collectList()
+                    .doOnSuccess(b -> LOG.debug("Emitting batched items {}", b));
+            });
+
+        Flux.range(1, 20).flatMap(i -> collapsedProvider.apply(i))
+            .as(StepVerifier::create)
+            .expectNextCount(20)
+            .verifyComplete();
+    }
+
+    @Test
+    void should_not_execute_more_things_in_parallel_with_delay() {
+        collapsedProvider = createCollapserBase()
+            .withScheduler(Schedulers.parallel())
+            .withMaximumWaitTime(Duration.ofMillis(200))
+            .withBatchSize(5)
+            .withBatchScheduler(Schedulers.parallel())
+            .withBatchMaxConcurrency(2)
+            .withEmitScheduler(Schedulers.immediate())
             .build();
         //the throughput will be 10 ids per seconds (batch of 5 * parallelism 2) at 1 sec delayed execution
 
@@ -544,7 +581,41 @@ public class FanOutRequestCollapserTest {
                     .doOnSuccess(b -> LOG.debug("Emitting batched items {}", b));
             });
 
-        Flux.range(1, 100).flatMap(i -> collapsedProvider.apply(i)).blockLast();
+        Flux.range(1, 100).flatMap(i -> collapsedProvider.apply(i))
+            .as(StepVerifier::create)
+            .verifyErrorSatisfies(e -> assertThat(e)
+                .isInstanceOf(BulkheadFullException.class)
+                .hasMessageContaining("Bulkhead 'fan out bulkhead' is full"));
+    }
+
+    @Test
+    void should_not_execute_more_things_in_parallel_with_delay_but_wait_for_it() {
+        collapsedProvider = createCollapserBase()
+            .withScheduler(Schedulers.parallel())
+            .withMaximumWaitTime(Duration.ofMillis(200))
+            .withBatchSize(5)
+            .withBatchScheduler(Schedulers.parallel())
+            .withBatchMaxConcurrency(2)
+            .withBatchMaxConcurrencyWaitTime(Duration.ofMillis(140))
+            .withEmitScheduler(Schedulers.immediate())
+            .build();
+        //the throughput will be 10 ids per seconds (batch of 5 * parallelism 2) at 1 sec delayed execution
+
+        when(bulkProvider.apply(anyList()))
+            .thenAnswer(ia -> {
+                List<Integer> params = (List<Integer>) ia.getArguments()[0];
+                LOG.debug("Returning delayed batched items for {}", params);
+                return Flux.fromIterable(params)
+                    .map(Object::toString)
+                    .collectList()
+                    .delayElement(Duration.ofMillis(100))
+                    .doOnSuccess(b -> LOG.debug("Emitting batched items {}", b));
+            });
+
+        Flux.range(1, 20).flatMap(i -> collapsedProvider.apply(i))
+            .as(StepVerifier::create)
+            .expectNextCount(20)
+            .verifyComplete();
     }
 
     /**
@@ -553,15 +624,7 @@ public class FanOutRequestCollapserTest {
     @Test
     void should_complete_if_contract_is_not_followed() {
         doReturn(Mono.empty()).when(bulkProvider).apply(any());
-        collapsedProvider = FanOutRequestCollapser.collapseCallsOver(bulkProvider)
-            .withContextValueMatcher((ctx, value) -> ctx.equals(Integer.parseInt(value)))
-            .withScheduler(scheduler)
-            .withEmitScheduler(emitScheduler)
-            .withMaximumWaitTime(Duration.ofMillis(100))
-            .withBatchSize(2)
-            .withBatchScheduler(batchScheduler)
-            .withMetrics(meterRegistry, MetricId.builder().name("metrics").hierarchicalName("metrics").build())
-            .build();
+        collapsedProvider = createCollapserBase().build();
 
         AssertSubscriber<String> subscriber1 = AssertSubscriber.create();
         collapsedProvider.apply(CONTEXT_A).subscribe(subscriber1);

--- a/molten-core/src/test/java/com/hotels/molten/core/collapser/FanOutRequestCollapserTest.java
+++ b/molten-core/src/test/java/com/hotels/molten/core/collapser/FanOutRequestCollapserTest.java
@@ -507,6 +507,7 @@ public class FanOutRequestCollapserTest {
             .withBatchScheduler(Schedulers.parallel())
             .withBatchMaxConcurrency(2)
             .withEmitScheduler(Schedulers.immediate())
+            .withGroupId("test-collapser")
             .build();
         //the throughput will be 10 ids per seconds (batch of 5 * parallelism 2) at 1 sec delayed execution
 
@@ -525,7 +526,7 @@ public class FanOutRequestCollapserTest {
             .as(StepVerifier::create)
             .verifyErrorSatisfies(e -> assertThat(e)
                 .isInstanceOf(BulkheadFullException.class)
-                .hasMessageContaining("Bulkhead 'fan out bulkhead' is full"));
+                .hasMessageContaining("Bulkhead 'test-collapser' is full"));
     }
 
     @Test
@@ -567,6 +568,7 @@ public class FanOutRequestCollapserTest {
             .withBatchScheduler(Schedulers.parallel())
             .withBatchMaxConcurrency(2)
             .withEmitScheduler(Schedulers.immediate())
+            .withGroupId("test-collapser")
             .build();
         //the throughput will be 10 ids per seconds (batch of 5 * parallelism 2) at 1 sec delayed execution
 
@@ -585,7 +587,7 @@ public class FanOutRequestCollapserTest {
             .as(StepVerifier::create)
             .verifyErrorSatisfies(e -> assertThat(e)
                 .isInstanceOf(BulkheadFullException.class)
-                .hasMessageContaining("Bulkhead 'fan out bulkhead' is full"));
+                .hasMessageContaining("Bulkhead 'test-collapser' is full"));
     }
 
     @Test

--- a/molten-platform/pom.xml
+++ b/molten-platform/pom.xml
@@ -550,6 +550,7 @@
           <reuseForks>true</reuseForks>
           <argLine>
             -Djunit.jupiter.displayname.generator.default=org.junit.jupiter.api.DisplayNameGenerator$ReplaceUnderscores
+            -Dreactor.schedulers.defaultPoolSize=8
           </argLine>
         </configuration>
         <dependencies>


### PR DESCRIPTION
### :pencil: Description

- Added `FanOutRequestCollapser.Builder#withGroupId`, so two instance can be differentiated when observing the logs.
- Added `FanOutRequestCollapser.Builder#withBatchMaxConcurrencyWaitTime` to set the max wait time for a full bulkhead to free up before making the next call failed.
- Made `FanOutRequestCollapser#maxConcurrency` limit forced by `Bulkhead` instead of the concurrency of `flatMap`,
  which killed the whole collapser instead of that single call over the limit.

### :link: Related Issues
none