### PR TITLE
Use Throwable#toString() instead of getMessage() when logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed `ReactiveCache` implementations to log the `Throwable#toString()` instead of the message, which can be null.
 
 ## [1.1.3]
 ### Changed

--- a/molten-cache/src/main/java/com/hotels/molten/cache/ReactiveReloadingCache.java
+++ b/molten-cache/src/main/java/com/hotels/molten/cache/ReactiveReloadingCache.java
@@ -159,7 +159,7 @@ public class ReactiveReloadingCache<CONTEXT, VALUE, CACHE_KEY, CACHED_VALUE> imp
                 LOG.debug("Storing item in cache for context={}", context);
                 put(context, value)
                     .subscribeOn(scheduler)
-                    .subscribe(v -> { }, ex -> LOG.warn("Error caching value for context={} cause={}", context, ex.getMessage()));
+                    .subscribe(v -> { }, ex -> LOG.warn("Error caching value for context={} cause={}", context, ex.toString()));
             })
             .doOnError(e -> loadExceptionCounter.increment())
             .onErrorResume(e -> failSafe ? Mono.empty() : Mono.error(e));
@@ -171,7 +171,7 @@ public class ReactiveReloadingCache<CONTEXT, VALUE, CACHE_KEY, CACHED_VALUE> imp
             .subscribeOn(scheduler)
             .subscribe(value -> { }, e -> {
                 asyncLoadExceptionCounter.increment();
-                LOG.warn("Couldn't reload expired value for context={} cause={}", context, e.getMessage());
+                LOG.warn("Couldn't reload expired value for context={} cause={}", context, e.toString());
             });
     }
 

--- a/molten-cache/src/main/java/com/hotels/molten/cache/resilience/FailSafeReactiveCache.java
+++ b/molten-cache/src/main/java/com/hotels/molten/cache/resilience/FailSafeReactiveCache.java
@@ -53,7 +53,7 @@ public class FailSafeReactiveCache<K, V> implements ReactiveCache<K, V> {
     private void logErrorForKey(String operation, K key, Throwable e) {
         switch (mode) {
         case LOGGING:
-            LOG.warn("Error invoking {} for key={} error-type={} error-message={}", operation, key, e.getClass().getName(), e.getMessage());
+            LOG.warn("Error invoking {} for key={} error={}", operation, key, e.toString());
             break;
         case VERBOSE:
             LOG.error("Error invoking {} for key={}", operation, key, e);

--- a/molten-cache/src/main/java/com/hotels/molten/cache/resilience/RetryingReactiveCache.java
+++ b/molten-cache/src/main/java/com/hotels/molten/cache/resilience/RetryingReactiveCache.java
@@ -70,7 +70,7 @@ public class RetryingReactiveCache<K, V> implements ReactiveCache<K, V> {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Retrying retry={} for method={} key={}", retryIndex, method, key, retry.failure());
                 } else if (LOG.isWarnEnabled()) {
-                    LOG.warn("Retrying retry={} for method={} key={} cause={}-{}", retryIndex, method, key, retry.failure().getClass().getName(), retry.failure().getMessage());
+                    LOG.warn("Retrying retry={} for method={} key={} cause={}-{}", retryIndex, method, key, retry.failure().getClass().getName(), retry.failure().toString());
                 }
                 MetricId.builder()
                     .name("cache_request_retries")
@@ -87,8 +87,7 @@ public class RetryingReactiveCache<K, V> implements ReactiveCache<K, V> {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Giving up retries after retry={} for method={} key={}", retry.totalRetries(), method, key, retry.failure());
                 } else if (LOG.isWarnEnabled()) {
-                    LOG.warn("Giving up retries after retry={} for method={} key={}, cause={}-{}", retry.totalRetries(), method, key, retry.failure().getClass().getName(),
-                        retry.failure().getMessage());
+                    LOG.warn("Giving up retries after retry={} for method={} key={}, cause={}", retry.totalRetries(), method, key, retry.failure().toString());
                 }
                 return retry.failure();
             });

--- a/molten-core/src/main/java/com/hotels/molten/core/collapser/FanOutRequestCollapser.java
+++ b/molten-core/src/main/java/com/hotels/molten/core/collapser/FanOutRequestCollapser.java
@@ -178,7 +178,7 @@ public final class FanOutRequestCollapser<CONTEXT, VALUE> implements Function<CO
     private void logEmission(ContextWithValue<CONTEXT, VALUE> item) {
         if (LOG.isDebugEnabled()) {
             if (item.error != null) {
-                LOG.debug("Emitting error for context={} error={}", item.contextWithSubject.context, item.error.getMessage());
+                LOG.debug("Emitting error for context={} error={}", item.contextWithSubject.context, item.error.toString());
             } else if (item.value != null) {
                 LOG.debug("Emitting item for context={} item={}", item.contextWithSubject.context, item.value);
             } else {

--- a/molten-core/src/test/java/com/hotels/molten/core/collapser/FanOutRequestCollapserTest.java
+++ b/molten-core/src/test/java/com/hotels/molten/core/collapser/FanOutRequestCollapserTest.java
@@ -410,7 +410,7 @@ public class FanOutRequestCollapserTest {
             Flux.range(0, numberOfIdsPerThread)
                 .map(i -> rng.nextInt(highestId))
                 .doOnNext(idsRolled::add)
-                .flatMap(id -> requestCollapser.apply(id).doOnError(e -> LOG.error("id={} error={}", id, e.getMessage())).onErrorResume(e -> Mono.empty()))
+                .flatMap(id -> requestCollapser.apply(id).doOnError(e -> LOG.error("id={} error={}", id, e.toString())).onErrorResume(e -> Mono.empty()))
                 .collectList()
                 .doOnSuccess(idsFinished::addAll)
                 .subscribe(subscriber);


### PR DESCRIPTION
### :pencil: Description
Changed to use `Throwable#toString()` instead of `getMessage()` when logging an error. This makes errors with no messages identifiable, instead of the previously printed `error=null`.

### :link: Related Issues
