### PR TITLE
Make vert.x internal dependency only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Made [Vert.x](https://vertx.io/) internal dependency only. It means that vert.x version is no longer managed by `molten-dependencies`.
 ### Fixed
 - Fixed `ReactiveCache` implementations to log the `Throwable#toString()` instead of the message, which can be null.
 

--- a/molten-dependencies/pom.xml
+++ b/molten-dependencies/pom.xml
@@ -28,7 +28,6 @@
     <kryo.version>4.0.2</kryo.version>
     <kryo-serializers.version>0.45</kryo-serializers.version>
     <jsr305.version>3.0.2</jsr305.version>
-    <vertx.version>3.9.4</vertx.version>
     <netty.version>4.1.59.Final</netty.version>
     <reactor-netty.version>1.0.5</reactor-netty.version>
     <protobuf.version>3.0.0</protobuf.version>
@@ -148,18 +147,6 @@
         <groupId>de.javakaffee</groupId>
         <artifactId>kryo-serializers</artifactId>
         <version>${kryo-serializers.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-core</artifactId>
-        <version>${vertx.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-web</artifactId>
-        <version>${vertx.version}</version>
-        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/molten-root/pom.xml
+++ b/molten-root/pom.xml
@@ -21,6 +21,7 @@
     <skip.integration.tests>false</skip.integration.tests>
     <!-- versions -->
     <testcontainers.version>1.15.3</testcontainers.version>
+    <vertx.version>3.9.4</vertx.version>
   </properties>
 
   <modules>
@@ -59,6 +60,18 @@
         <version>${testcontainers.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-core</artifactId>
+        <version>${vertx.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-web</artifactId>
+        <version>${vertx.version}</version>
+        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/readme.md
+++ b/readme.md
@@ -37,8 +37,6 @@ Some libraries building on:
   - [Guava](https://github.com/google/guava)
   - [Slf4j](http://www.slf4j.org/)
   - [Logback](http://logback.qos.ch/)
-  - [Vert.x](https://vertx.io/)
-  - [AWS Java SDK](https://aws.amazon.com/sdk-for-java/)
 
 ## Requirements
 


### PR DESCRIPTION
### :pencil: Description
Vert.x is actually an internal test-scope dependency, shouldn't be included in the `molten-dependencies` bom.

### :link: Related Issues
none