### PR TITLE
Add eager mode to FanOutRequestCollapser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `FanOutRequestCollapser#collapseCallsEagerlyOver` to allow bulk providers to emmit partial results eagerly before the whole bulk call is completed.
+### Changed
+- Constructor of `FanOutRequestCollapser.Builder` become private, please use the static factory methods to start building one.
 
 ## [1.2.1]
 ### Fixed

--- a/molten-core/src/main/java/com/hotels/molten/core/collapser/FanOutRequestCollapser.java
+++ b/molten-core/src/main/java/com/hotels/molten/core/collapser/FanOutRequestCollapser.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import java.time.Duration;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -60,8 +61,8 @@ import com.hotels.molten.core.metrics.MetricId;
  * <li>Waits for a full chunk maximum for a given time. See {@link Builder#withMaximumWaitTime(Duration)}.</li>
  * <li>Propagates returned values to respective caller by matching value with its context. See {@link Builder#withContextValueMatcher(BiFunction)}.</li>
  * <li>Propagates result on a given {@link Scheduler}. See {@link Builder#withScheduler(Scheduler)}.</li>
- * <li>Bulk provider error is propagated to each caller taking part in that call.</li>
- * <li>Matching error is logged but ignored. Respective call will get empty result.</li>
+ * <li>Bulk provider error is propagated to each caller taking part in that call {@link #collapseCallsOver(Function)}  in lazy mode},
+ * or to each not yet answered caller in {@link #collapseCallsEagerlyOver(Function)}  in eager mode}.</li>
  * <li>Non-matched contexts will get empty result.</li>
  * </ul>
  * <p>
@@ -113,14 +114,15 @@ public final class FanOutRequestCollapser<CONTEXT, VALUE> implements Function<CO
                 List<CONTEXT> contexts = toContexts(contextsWithSubjects);
                 LOG.debug("Executing batch with contexts={}, groupId={}", contexts, groupId);
                 updateMetrics(contextsWithSubjects);
+                final List<ContextWithSubject<CONTEXT, VALUE>> contextsWithSubjectsToDrain = new LinkedList<>(contextsWithSubjects);
                 return Mono.just(contexts)
-                    .flatMap(builder.bulkProvider)
+                    .flatMapMany(builder.bulkProvider)
                     .subscribeOn(builder.batchScheduler)
+                    .flatMap(value -> bindValueToContext(contextsWithSubjectsToDrain, value, groupId))
+                    .concatWith(bindEmptyToRemaining(contextsWithSubjectsToDrain))
                     .transform(BulkheadOperator.of(bulkhead))
-                    .defaultIfEmpty(List.of())
                     .doOnError(e -> LOG.error("Error while delegating call for contexts={}, groupId={}", contexts, groupId, e))
-                    .flatMapMany(values -> Flux.fromIterable(contextsWithSubjects).flatMap(context -> bindValueToContext(context, values, groupId)))
-                    .onErrorResume(throwable -> Flux.fromIterable(contextsWithSubjects).map(context -> ContextWithValue.error(context, throwable)));
+                    .onErrorResume(throwable -> bindErrorToRemaining(contextsWithSubjectsToDrain, throwable));
             }, Integer.MAX_VALUE)
             .publishOn(builder.emitScheduler)
             .doOnNext(this::logEmission)
@@ -145,6 +147,33 @@ public final class FanOutRequestCollapser<CONTEXT, VALUE> implements Function<CO
                 return contextWithSubject.subject;
             })
             .transform(MoltenCore.propagateContext());
+    }
+
+    /**
+     * Creates a {@link FanOutRequestCollapser} builder over a bulk provider, emitting all the bulk results in one piece.<br>
+     * If you would rather emmit bulk results in several pieces, {@link #collapseCallsEagerlyOver} should be used instead.
+     *
+     * @param <C>          the context type
+     * @param <V>          the VALUE type
+     * @param bulkProvider the bulk provider to delegate calls to
+     * @return the builder
+     */
+    public static <C, V> Builder<C, V> collapseCallsOver(Function<List<C>, Mono<List<V>>> bulkProvider) {
+        return new Builder<>(requireNonNull(bulkProvider).andThen(listMono -> listMono.flatMapMany(Flux::fromIterable)));
+    }
+
+    /**
+     * Creates a {@link FanOutRequestCollapser} builder over a bulk provider, possibly emitting the bulk results in several pieces.
+     * The eagerly emitted results are eagerly sent to the respective callers by the fan-out request collapser.<br>
+     * If you would rather emmit bulk results in one piece, {@link #collapseCallsOver} should be used instead.
+     *
+     * @param <C>          the context type
+     * @param <V>          the VALUE type
+     * @param bulkProvider the bulk provider to delegate calls to
+     * @return the builder
+     */
+    public static <C, V> Builder<C, V> collapseCallsEagerlyOver(Function<List<C>, Flux<V>> bulkProvider) {
+        return new Builder<>(bulkProvider);
     }
 
     /**
@@ -198,29 +227,36 @@ public final class FanOutRequestCollapser<CONTEXT, VALUE> implements Function<CO
         }
     }
 
-    /**
-     * Creates a {@link FanOutRequestCollapser} builder over a bulk provider.
-     *
-     * @param <C>          the context type
-     * @param <V>          the VALUE type
-     * @param bulkProvider the bulk provider to delegate calls to
-     * @return the builder
-     */
-    public static <C, V> Builder<C, V> collapseCallsOver(Function<List<C>, Mono<List<V>>> bulkProvider) {
-        return new Builder<>(bulkProvider);
-    }
-
     private List<CONTEXT> toContexts(List<ContextWithSubject<CONTEXT, VALUE>> contextWithSubjects) {
         return contextWithSubjects.stream().map(cs -> cs.context).collect(Collectors.toList());
     }
 
-    private Mono<ContextWithValue<CONTEXT, VALUE>> bindValueToContext(ContextWithSubject<CONTEXT, VALUE> contextWithSubject, List<VALUE> values, String groupId) {
-        return Flux.fromIterable(values)
-            .filter(value -> matchContextByValue(contextWithSubject.context, value, groupId))
-            .next()
-            .map(value -> ContextWithValue.value(contextWithSubject, value))
-            .onErrorResume(e -> Mono.just(ContextWithValue.error(contextWithSubject, e)))
-            .defaultIfEmpty(ContextWithValue.empty(contextWithSubject));
+    private Mono<ContextWithValue<CONTEXT, VALUE>> bindValueToContext(List<ContextWithSubject<CONTEXT, VALUE>> contextsWithSubjects, VALUE value, String groupId) {
+        synchronized (contextsWithSubjects) {
+            ContextWithSubject<CONTEXT, VALUE> firstMatch = null;
+            for (var contextWithSubject : contextsWithSubjects) {
+                if (matchContextByValue(contextWithSubject.context, value, groupId)) {
+                    firstMatch = contextWithSubject;
+                }
+            }
+            if (firstMatch != null) {
+                contextsWithSubjects.remove(firstMatch);
+            }
+            return Mono.justOrEmpty(firstMatch)
+                .map(contextWithSubject -> ContextWithValue.value(contextWithSubject, value));
+        }
+    }
+
+    private Flux<ContextWithValue<CONTEXT, VALUE>> bindEmptyToRemaining(List<ContextWithSubject<CONTEXT, VALUE>> contextsWithSubjects) {
+        synchronized (contextsWithSubjects) {
+            return Flux.fromIterable(contextsWithSubjects).map(ContextWithValue::empty);
+        }
+    }
+
+    private Flux<ContextWithValue<CONTEXT, VALUE>> bindErrorToRemaining(List<ContextWithSubject<CONTEXT, VALUE>> contextsWithSubjects, Throwable throwable) {
+        synchronized (contextsWithSubjects) {
+            return Flux.fromIterable(contextsWithSubjects).map(contextWithSubject -> ContextWithValue.error(contextWithSubject, throwable));
+        }
     }
 
     private boolean matchContextByValue(CONTEXT context, VALUE value, String groupId) {
@@ -295,7 +331,7 @@ public final class FanOutRequestCollapser<CONTEXT, VALUE> implements Function<CO
      * @param <V> the VALUE type
      */
     public static final class Builder<C, V> {
-        private final Function<List<C>, Mono<List<V>>> bulkProvider;
+        private final Function<List<C>, Flux<V>> bulkProvider;
         private int maxConcurrency = Runtime.getRuntime().availableProcessors();
         private BiFunction<C, V, Boolean> contextValueMatcher;
         private Scheduler scheduler = Schedulers.parallel();
@@ -308,7 +344,7 @@ public final class FanOutRequestCollapser<CONTEXT, VALUE> implements Function<CO
         private MetricId metricId;
         private String groupId = "unknown";
 
-        public Builder(Function<List<C>, Mono<List<V>>> bulkProvider) {
+        private Builder(Function<List<C>, Flux<V>> bulkProvider) {
             this.bulkProvider = requireNonNull(bulkProvider);
         }
 

--- a/molten-core/src/test/java/com/hotels/molten/core/collapser/FanOutRequestCollapserTest.java
+++ b/molten-core/src/test/java/com/hotels/molten/core/collapser/FanOutRequestCollapserTest.java
@@ -711,7 +711,7 @@ public class FanOutRequestCollapserTest {
             });
 
         assertThat(countDown.getCount()).isNotZero();
-        assertThat(countDown.await(500, TimeUnit.MILLISECONDS)).describedAs("Couldn't finish calls successfully in time.").isTrue();
+        assertThat(countDown.await(1, TimeUnit.SECONDS)).describedAs("Couldn't finish calls successfully in time.").isTrue();
         assertThat(captor.getValue()).containsExactlyInAnyOrder(CONTEXT_A, CONTEXT_B, CONTEXT_C);
         verify(eagerBulkProvider, only()).apply(any());
     }
@@ -751,7 +751,7 @@ public class FanOutRequestCollapserTest {
             }, countDown::countDown);
 
         assertThat(countDown.getCount()).isNotZero();
-        assertThat(countDown.await(500, TimeUnit.MILLISECONDS)).describedAs("Couldn't finish calls successfully in time.").isTrue();
+        assertThat(countDown.await(1, TimeUnit.SECONDS)).describedAs("Couldn't finish calls successfully in time.").isTrue();
         assertThat(captor.getValue()).containsExactlyInAnyOrder(CONTEXT_A, CONTEXT_B, CONTEXT_C);
         verify(eagerBulkProvider, only()).apply(any());
     }
@@ -791,7 +791,7 @@ public class FanOutRequestCollapserTest {
             });
 
         assertThat(countDown.getCount()).isNotZero();
-        assertThat(countDown.await(500, TimeUnit.MILLISECONDS)).describedAs("Couldn't finish calls successfully in time.").isTrue();
+        assertThat(countDown.await(1, TimeUnit.SECONDS)).describedAs("Couldn't finish calls successfully in time.").isTrue();
         assertThat(captor.getValue()).containsExactlyInAnyOrder(CONTEXT_A, CONTEXT_B, CONTEXT_C);
         verify(eagerBulkProvider, only()).apply(any());
     }
@@ -832,7 +832,7 @@ public class FanOutRequestCollapserTest {
             });
 
         assertThat(countDown.getCount()).isNotZero();
-        assertThat(countDown.await(500, TimeUnit.MILLISECONDS)).describedAs("Couldn't finish calls successfully in time.").isTrue();
+        assertThat(countDown.await(1, TimeUnit.SECONDS)).describedAs("Couldn't finish calls successfully in time.").isTrue();
         assertThat(captor.getValue()).containsExactlyInAnyOrder(CONTEXT_A, CONTEXT_B, CONTEXT_C);
         verify(eagerBulkProvider, only()).apply(any());
     }

--- a/molten-core/src/test/java/com/hotels/molten/core/collapser/FanOutRequestCollapserTest.java
+++ b/molten-core/src/test/java/com/hotels/molten/core/collapser/FanOutRequestCollapserTest.java
@@ -710,7 +710,6 @@ public class FanOutRequestCollapserTest {
                 countDown.countDown();
             });
 
-        assertThat(countDown.getCount()).isNotZero();
         assertThat(countDown.await(1, TimeUnit.SECONDS)).describedAs("Couldn't finish calls successfully in time.").isTrue();
         assertThat(captor.getValue()).containsExactlyInAnyOrder(CONTEXT_A, CONTEXT_B, CONTEXT_C);
         verify(eagerBulkProvider, only()).apply(any());
@@ -750,7 +749,6 @@ public class FanOutRequestCollapserTest {
                 throw new IllegalStateException("Unexpected error", error);
             }, countDown::countDown);
 
-        assertThat(countDown.getCount()).isNotZero();
         assertThat(countDown.await(1, TimeUnit.SECONDS)).describedAs("Couldn't finish calls successfully in time.").isTrue();
         assertThat(captor.getValue()).containsExactlyInAnyOrder(CONTEXT_A, CONTEXT_B, CONTEXT_C);
         verify(eagerBulkProvider, only()).apply(any());
@@ -790,7 +788,6 @@ public class FanOutRequestCollapserTest {
                 countDown.countDown();
             });
 
-        assertThat(countDown.getCount()).isNotZero();
         assertThat(countDown.await(1, TimeUnit.SECONDS)).describedAs("Couldn't finish calls successfully in time.").isTrue();
         assertThat(captor.getValue()).containsExactlyInAnyOrder(CONTEXT_A, CONTEXT_B, CONTEXT_C);
         verify(eagerBulkProvider, only()).apply(any());
@@ -831,7 +828,6 @@ public class FanOutRequestCollapserTest {
                 countDown.countDown();
             });
 
-        assertThat(countDown.getCount()).isNotZero();
         assertThat(countDown.await(1, TimeUnit.SECONDS)).describedAs("Couldn't finish calls successfully in time.").isTrue();
         assertThat(captor.getValue()).containsExactlyInAnyOrder(CONTEXT_A, CONTEXT_B, CONTEXT_C);
         verify(eagerBulkProvider, only()).apply(any());


### PR DESCRIPTION
### :pencil: Description
Adds sort of an eager mode to `FanOutRequestCollapser`, so bulk providers are allowed to emmit partial results eagerly before the whole bulk call is completed.

### :link: Related Issues
none