### PR TITLE
Add different timeout only for put operations in ResilientReactiveCache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `ResilientReactiveCacheBuilder#withPutTimeout` to set a different timeout only for put operations.
 
 ## [1.2.1]
 ### Fixed

--- a/build/suppressions.xml
+++ b/build/suppressions.xml
@@ -8,4 +8,5 @@
   <suppress checks="IllegalInstantiation" files="com.hotels.molten.http.client.HttpException"/>
   <suppress checks="FinalClass" files="com.hotels.molten.cache.ReactiveReloadingCache"/>
   <suppress checks="UnnecessaryParentheses" files="com.hotels.molten.trace.AbstractTracer"/>
+  <suppress checks="ParameterNumber" files="com.hotels.molten.cache.resilience.ResilientReactiveCache"/>
 </suppressions>

--- a/molten-cache/src/main/java/com/hotels/molten/cache/resilience/ResilientReactiveCache.java
+++ b/molten-cache/src/main/java/com/hotels/molten/cache/resilience/ResilientReactiveCache.java
@@ -76,8 +76,8 @@ public class ResilientReactiveCache<K, V> implements ReactiveCache<K, V> {
         @NonNull CircuitBreakerConfig circuitBreakerConfig,
         @NonNull MeterRegistry meterRegistry
     ) {
-        this.reactiveCache = reactiveCache;
         checkState(USED_CACHE_NAMES.add(cacheName), "The cache name=" + cacheName + " cannot be reused.");
+        this.reactiveCache = reactiveCache;
         this.getTimeout = validateTimeout(timeout);
         this.putTimeout = Optional.ofNullable(putTimeout).map(this::validateTimeout).orElse(timeout);
         CircuitBreakerConfig finalCircuitBreakerConfig = CircuitBreakerConfig.from(circuitBreakerConfig)

--- a/molten-cache/src/main/java/com/hotels/molten/cache/resilience/ResilientReactiveCache.java
+++ b/molten-cache/src/main/java/com/hotels/molten/cache/resilience/ResilientReactiveCache.java
@@ -19,13 +19,14 @@ package com.hotels.molten.cache.resilience;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.hotels.molten.core.metrics.MetricsSupport.name;
-import static java.util.Objects.requireNonNull;
 
 import java.time.Duration;
-import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.LongAdder;
+import javax.annotation.Nullable;
 
 import com.google.common.base.Throwables;
 import io.github.resilience4j.bulkhead.BulkheadFullException;
@@ -34,6 +35,7 @@ import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.github.resilience4j.reactor.circuitbreaker.operator.CircuitBreakerOperator;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
+import lombok.NonNull;
 import reactor.core.publisher.Mono;
 
 import com.hotels.molten.cache.ReactiveCache;
@@ -42,31 +44,42 @@ import com.hotels.molten.metrics.resilience.CircuitBreakerInstrumenter;
 
 /**
  * Resilient {@link ReactiveCache} with timeout and circuit-breaker.
- * Should be wrapped around an {@link ResilientSharedReactiveCache}.
+ * Consider using {@link ResilientReactiveCacheBuilder} to create a more robust resilient cache.<br>
+ * Should be wrapped around an {@link ResilientSharedReactiveCache}.<br>
  * Please note that the provided {@link CircuitBreakerConfig} will be altered in a way it ignores {@link BulkheadFullException} in the causal chain as a failure.
  * Instruments circuit-breaker with {@link CircuitBreakerInstrumenter}.
  *
  * @param <K> the type of key
  * @param <V> the type of value
  * @see ResilientSharedReactiveCache
+ * @see ResilientReactiveCacheBuilder
  */
-@SuppressWarnings("unchecked")
 public class ResilientReactiveCache<K, V> implements ReactiveCache<K, V> {
     private static final String HIERARCHICAL_METRICS_PREFIX = "reactive-cache";
-    private static final Map<String, String> USED_CACHE_NAMES = new ConcurrentHashMap<>();
+    private static final Set<String> USED_CACHE_NAMES = ConcurrentHashMap.newKeySet();
     private final ReactiveCache<K, V> reactiveCache;
-    private final Duration timeout;
+    private final Duration getTimeout;
+    private final Duration putTimeout;
     private final CircuitBreaker circuitBreaker;
     private final LongAdder timedOutGetCount = new LongAdder();
     private final LongAdder timedOutPutCount = new LongAdder();
 
     public ResilientReactiveCache(ReactiveCache<K, V> reactiveCache, String cacheName, Duration timeout, CircuitBreakerConfig circuitBreakerConfig, MeterRegistry meterRegistry) {
-        this.reactiveCache = requireNonNull(reactiveCache);
-        requireNonNull(cacheName);
-        requireNonNull(meterRegistry);
-        checkState(USED_CACHE_NAMES.putIfAbsent(cacheName, cacheName) == null, "The cache name=" + cacheName + " cannot be reused.");
-        checkArgument(timeout.toMillis() > 0, "timeout must be positive but was " + timeout);
-        this.timeout = timeout;
+        this(reactiveCache, cacheName, timeout, null, circuitBreakerConfig, meterRegistry);
+    }
+
+    public ResilientReactiveCache(
+        @NonNull ReactiveCache<K, V> reactiveCache,
+        @NonNull String cacheName,
+        @NonNull Duration timeout,
+        @Nullable Duration putTimeout,
+        @NonNull CircuitBreakerConfig circuitBreakerConfig,
+        @NonNull MeterRegistry meterRegistry
+    ) {
+        this.reactiveCache = reactiveCache;
+        checkState(USED_CACHE_NAMES.add(cacheName), "The cache name=" + cacheName + " cannot be reused.");
+        this.getTimeout = validateTimeout(timeout);
+        this.putTimeout = Optional.ofNullable(putTimeout).map(this::validateTimeout).orElse(timeout);
         CircuitBreakerConfig finalCircuitBreakerConfig = CircuitBreakerConfig.from(circuitBreakerConfig)
             .recordException(e -> Throwables.getCausalChain(e).stream().noneMatch(ex -> ex instanceof BulkheadFullException))
             .build();
@@ -92,7 +105,7 @@ public class ResilientReactiveCache<K, V> implements ReactiveCache<K, V> {
     @Override
     public Mono<V> get(K key) {
         return reactiveCache.get(key)
-            .timeout(timeout)
+            .timeout(getTimeout)
             .doOnError(e -> {
                 if (e instanceof TimeoutException) {
                     timedOutGetCount.increment();
@@ -104,7 +117,7 @@ public class ResilientReactiveCache<K, V> implements ReactiveCache<K, V> {
     @Override
     public Mono<Void> put(K key, V value) {
         return reactiveCache.put(key, value)
-            .timeout(timeout)
+            .timeout(putTimeout)
             .doOnError(e -> {
                 if (e instanceof TimeoutException) {
                     timedOutPutCount.increment();
@@ -113,8 +126,13 @@ public class ResilientReactiveCache<K, V> implements ReactiveCache<K, V> {
             .transform(CircuitBreakerOperator.of(circuitBreaker));
     }
 
-    private CircuitBreaker createCircuitBreaker(String cacheName, MeterRegistry meterRegistry, CircuitBreakerConfig finalCircuitBreakerConfig) {
-        CircuitBreaker circuitBreaker = CircuitBreaker.of(cacheName, finalCircuitBreakerConfig);
+    private Duration validateTimeout(Duration timeout) {
+        checkArgument(timeout.toMillis() > 0, "timeout must be positive but was " + timeout);
+        return timeout;
+    }
+
+    private CircuitBreaker createCircuitBreaker(String cacheName, MeterRegistry meterRegistry, CircuitBreakerConfig circuitBreakerConfig) {
+        CircuitBreaker circuitBreaker = CircuitBreaker.of(cacheName, circuitBreakerConfig);
         CircuitBreakerInstrumenter.builder()
             .meterRegistry(meterRegistry)
             .metricsQualifier("cache_request_circuit")

--- a/molten-cache/src/main/java/com/hotels/molten/cache/resilience/ResilientReactiveCacheBuilder.java
+++ b/molten-cache/src/main/java/com/hotels/molten/cache/resilience/ResilientReactiveCacheBuilder.java
@@ -59,6 +59,7 @@ public class ResilientReactiveCacheBuilder<K, V> {
     private String cacheName;
     private Duration ttl = Duration.ofHours(1);
     private Duration timeout = Duration.ofMillis(50);
+    private Duration putTimeout;
     private FailSafeMode failsafe = FailSafeMode.VERBOSE;
     private RetryBackoffSpec retry;
     private int retries;
@@ -74,7 +75,7 @@ public class ResilientReactiveCacheBuilder<K, V> {
     /**
      * Creates a resilient cache builder.
      *
-     * @param <KEY> the key type
+     * @param <KEY>   the key type
      * @param <VALUE> the value type
      * @return the builder
      */
@@ -92,7 +93,7 @@ public class ResilientReactiveCacheBuilder<K, V> {
         checkArgument(CACHES.putIfAbsent(cacheName, cacheName) == null, "The cache name=" + cacheName + " has been already used");
         requireNonNull(meterRegistry);
         ReactiveCache<K, V> cache = new NamedReactiveCache<>(sharedResilientCache, cacheName, ttl);
-        cache = new ResilientReactiveCache<>(cache, cacheName, timeout, circuitBreakerConfig, meterRegistry);
+        cache = new ResilientReactiveCache<>(cache, cacheName, timeout, putTimeout, circuitBreakerConfig, meterRegistry);
         cache = new InstrumentedReactiveCache<>(cache, meterRegistry, cacheName, "single");
         if (retry != null) {
             cache = new RetryingReactiveCache<>(cache, retry, meterRegistry, cacheName);
@@ -109,47 +110,60 @@ public class ResilientReactiveCacheBuilder<K, V> {
     /**
      * Sets the cache to delegate calls to. Usually a shared (remote) cache instance.
      *
-     * @param val the cache to wrap
+     * @param reactiveCache the cache to wrap
      * @return this builder instance
      */
-    public ResilientReactiveCacheBuilder<K, V> over(ReactiveCache<NamedCacheKey<K>, CachedValue<V>> val) {
-        sharedResilientCache = requireNonNull(val);
+    public ResilientReactiveCacheBuilder<K, V> over(ReactiveCache<NamedCacheKey<K>, CachedValue<V>> reactiveCache) {
+        sharedResilientCache = requireNonNull(reactiveCache);
         return this;
     }
 
     /**
      * Sets the name of the cache.
      *
-     * @param val the cache name
+     * @param cacheName the cache name
      * @return this builder instance
      */
-    public ResilientReactiveCacheBuilder<K, V> withCacheName(String val) {
-        checkArgument(!isNullOrEmpty(val), "Cache name must have value");
-        cacheName = val;
+    public ResilientReactiveCacheBuilder<K, V> withCacheName(String cacheName) {
+        checkArgument(!isNullOrEmpty(cacheName), "Cache name must have value");
+        this.cacheName = cacheName;
         return this;
     }
 
     /**
      * Sets the TTL of the entries.
      *
-     * @param val the cache name
+     * @param ttl the cache name
      * @return this builder instance
      */
-    public ResilientReactiveCacheBuilder<K, V> withTTL(Duration val) {
-        checkArgument(val != null && !val.isNegative(), "TTL must be positive but was " + val);
-        ttl = val;
+    public ResilientReactiveCacheBuilder<K, V> withTTL(Duration ttl) {
+        checkArgument(ttl != null && !ttl.isNegative(), "TTL must be positive but was " + ttl);
+        this.ttl = ttl;
         return this;
     }
 
     /**
      * Sets the timeout for the cache calls.
+     * If {@link #withPutTimeout putTimeout} is set, it's for 'get' calls only.
      *
-     * @param val the timeout
+     * @param timeout the timeout
      * @return this builder instance
      */
-    public ResilientReactiveCacheBuilder<K, V> withTimeout(Duration val) {
-        checkArgument(val != null && !val.isNegative(), "Timeout must be positive but was " + val);
-        timeout = val;
+    public ResilientReactiveCacheBuilder<K, V> withTimeout(Duration timeout) {
+        checkArgument(timeout != null && !timeout.isNegative(), "Timeout must be positive but was " + timeout);
+        this.timeout = timeout;
+        return this;
+    }
+
+    /**
+     * Sets the timeout for the cache 'put' calls only.
+     *
+     * @param putTimeout the timeout
+     * @return this builder instance
+     */
+    public ResilientReactiveCacheBuilder<K, V> withPutTimeout(Duration putTimeout) {
+        checkArgument(putTimeout != null && !putTimeout.isNegative(), "Timeout must be positive but was " + putTimeout);
+        this.putTimeout = putTimeout;
         return this;
     }
 
@@ -207,21 +221,26 @@ public class ResilientReactiveCacheBuilder<K, V> {
     }
 
     /**
-     * The configuration of the circuitbreaker over cache calls.
+     * Sets the configuration of the circuitbreaker over cache calls.
      *
-     * @param val the circuitbreaker configuration
+     * @param circuitBreakerConfig the circuitbreaker configuration
      * @return this builder instance
      */
-    public ResilientReactiveCacheBuilder<K, V> withCircuitBreakerConfig(CircuitBreakerConfig val) {
-        checkArgument(val != null, "Circuit breaker config must be non-null");
-        circuitBreakerConfig = val;
+    public ResilientReactiveCacheBuilder<K, V> withCircuitBreakerConfig(CircuitBreakerConfig circuitBreakerConfig) {
+        checkArgument(circuitBreakerConfig != null, "Circuit breaker config must be non-null");
+        this.circuitBreakerConfig = circuitBreakerConfig;
         return this;
     }
 
-
-    public ResilientReactiveCacheBuilder<K, V> withMeterRegistry(MeterRegistry val) {
-        checkArgument(val != null, "Metric registry must be non-null");
-        meterRegistry = val;
+    /**
+     * Sets the meter registry to register the meters of the resilient cache calls to.
+     *
+     * @param meterRegistry the meter registry
+     * @return the builder instance
+     */
+    public ResilientReactiveCacheBuilder<K, V> withMeterRegistry(MeterRegistry meterRegistry) {
+        checkArgument(meterRegistry != null, "Metric registry must be non-null");
+        this.meterRegistry = meterRegistry;
         return this;
     }
 }

--- a/molten-cache/src/main/java/com/hotels/molten/cache/resilience/ResilientReactiveCacheBuilder.java
+++ b/molten-cache/src/main/java/com/hotels/molten/cache/resilience/ResilientReactiveCacheBuilder.java
@@ -21,8 +21,6 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Objects.requireNonNull;
 
 import java.time.Duration;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -54,7 +52,6 @@ import com.hotels.molten.cache.metrics.InstrumentedReactiveCache;
  * @see ResilientReactiveCache
  */
 public class ResilientReactiveCacheBuilder<K, V> {
-    private static final Map<String, String> CACHES = new ConcurrentHashMap<>();
     private ReactiveCache<NamedCacheKey<K>, CachedValue<V>> sharedResilientCache;
     private String cacheName;
     private Duration ttl = Duration.ofHours(1);
@@ -90,7 +87,6 @@ public class ResilientReactiveCacheBuilder<K, V> {
      */
     public ReactiveCache<K, V> createCache() {
         checkArgument(!isNullOrEmpty(cacheName), "Cache name must have value");
-        checkArgument(CACHES.putIfAbsent(cacheName, cacheName) == null, "The cache name=" + cacheName + " has been already used");
         requireNonNull(meterRegistry);
         ReactiveCache<K, V> cache = new NamedReactiveCache<>(sharedResilientCache, cacheName, ttl);
         cache = new ResilientReactiveCache<>(cache, cacheName, timeout, putTimeout, circuitBreakerConfig, meterRegistry);

--- a/molten-cache/src/main/java/com/hotels/molten/cache/resilience/ResilientSharedReactiveCache.java
+++ b/molten-cache/src/main/java/com/hotels/molten/cache/resilience/ResilientSharedReactiveCache.java
@@ -21,7 +21,7 @@ import static com.hotels.molten.core.metrics.MetricsSupport.name;
 import static java.util.Objects.requireNonNull;
 
 import java.time.Duration;
-import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import io.github.resilience4j.bulkhead.Bulkhead;
@@ -45,7 +45,7 @@ import com.hotels.molten.metrics.resilience.BulkheadInstrumenter;
  */
 public class ResilientSharedReactiveCache<K, V> implements ReactiveCache<K, V> {
     private static final String HIERARCHICAL_METRICS_PREFIX = "reactive-cache";
-    private static final Map<String, String> USED_CACHE_NAMES = new ConcurrentHashMap<>();
+    private static final Set<String> USED_CACHE_NAMES = ConcurrentHashMap.newKeySet();
     private final ReactiveCache<K, V> sharedCache;
     private final Bulkhead getBulkhead;
     private final Bulkhead putBulkhead;
@@ -53,7 +53,7 @@ public class ResilientSharedReactiveCache<K, V> implements ReactiveCache<K, V> {
     public ResilientSharedReactiveCache(ReactiveCache<K, V> sharedCache, String cacheName, int maxConcurrency, MeterRegistry meterRegistry) {
         this.sharedCache = requireNonNull(sharedCache);
         requireNonNull(cacheName);
-        checkState(USED_CACHE_NAMES.putIfAbsent(cacheName, cacheName) == null, "The cache name [" + cacheName + "] cannot be reused.");
+        checkState(USED_CACHE_NAMES.add(cacheName), "The cache name=" + cacheName + " cannot be reused.");
         checkState(maxConcurrency > 0, "max concurrency must be positive");
 
         BulkheadConfig bulkheadConfig = BulkheadConfig.custom()

--- a/molten-cache/src/test/java/com/hotels/molten/cache/resilience/ResilientReactiveCacheTest.java
+++ b/molten-cache/src/test/java/com/hotels/molten/cache/resilience/ResilientReactiveCacheTest.java
@@ -19,6 +19,7 @@ package com.hotels.molten.cache.resilience;
 import static com.hotels.molten.core.metrics.MetricsSupport.GRAPHITE_ID;
 import static com.hotels.molten.core.metrics.MetricsSupport.name;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -267,6 +268,14 @@ public class ResilientReactiveCacheTest implements ReactiveCacheTestContract {
         assertThat(meterRegistry.get("reactive-cache." + cacheName + ".circuit." + "successful").gauge().value()).isEqualTo(0D);
         assertThat(meterRegistry.get("reactive-cache." + cacheName + ".circuit." + "failed").gauge().value()).isEqualTo(2D);
         assertThat(meterRegistry.get("reactive-cache." + cacheName + ".circuit." + "rejected").gauge().value()).isEqualTo(2D);
+    }
+
+    @Test
+    public void should_not_reuse_cache_name() {
+        getResilientCache(cache, CircuitBreakerConfig.ofDefaults());
+        assertThatThrownBy(() -> getResilientCache(cache, CircuitBreakerConfig.ofDefaults()))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("The cache name=" + cacheName + " cannot be reused.");
     }
 
     private String nextCacheName() {

--- a/molten-remote-cache/src/test/java/com/hotels/molten/cache/redis/RemoteRedisCacheIntegrationTest.java
+++ b/molten-remote-cache/src/test/java/com/hotels/molten/cache/redis/RemoteRedisCacheIntegrationTest.java
@@ -48,6 +48,8 @@ import org.testcontainers.utility.MountableFile;
 import reactor.test.StepVerifier;
 import reactor.util.retry.Retry;
 
+import com.hotels.molten.cache.CachedValue;
+import com.hotels.molten.cache.NamedCacheKey;
 import com.hotels.molten.cache.ReactiveCache;
 import com.hotels.molten.cache.redis.codec.FlatStringKeyCodec;
 import com.hotels.molten.cache.redis.codec.KryoRedisCodec;
@@ -89,7 +91,8 @@ public class RemoteRedisCacheIntegrationTest {
     }
 
     private ReactiveCache<ComplexKey, ComplexValue> reactiveCache() {
-        return ResilientReactiveCacheBuilder.<ComplexKey, ComplexValue>builder().over(sharedRemoteCache())
+        return ResilientReactiveCacheBuilder.<ComplexKey, ComplexValue>builder()
+            .over(sharedRemoteCache())
             .withCacheName("myCache")
             .withTimeout(Duration.ofMillis(1000))
             .withRetry(Retry.fixedDelay(10, Duration.ofSeconds(1)))
@@ -105,8 +108,8 @@ public class RemoteRedisCacheIntegrationTest {
             .createCache();
     }
 
-    private ReactiveCache sharedRemoteCache() {
-        return ResilientSharedReactiveRedisCacheBuilder.builder()
+    private <K, V> ReactiveCache<NamedCacheKey<K>, CachedValue<V>> sharedRemoteCache() {
+        return ResilientSharedReactiveRedisCacheBuilder.<K, V>builder()
             .withRedisConnection(() -> redisConnectionBuilder().createConnection())
             .withSharedCacheName("sharedRemoteCache")
             .withMaxConcurrency(2)


### PR DESCRIPTION
### :pencil: Description
Added `ResilientReactiveCacheBuilder#withPutTimeout` to set a different timeout only for put operations.

### :link: Related Issues
none