### PR TITLE
Make use of queue hook for context propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `FanOutRequestCollapser#collapseCallsEagerlyOver` to allow bulk providers to emmit partial results eagerly before the whole bulk call is completed.
 ### Changed
 - Constructor of `FanOutRequestCollapser.Builder` become private, please use the static factory methods to start building one.
+- Changed `onEachOperator` based MDC and trace propagation from `reactor.core.publisher.Hooks.onEachOperator` to `reactor.core.publisher.Hooks.addQueueWrapper` based implementation.
+- MDC and trace propagation always uses queue wrappers.
+### Deprecated
+- Deprecated `com.hotels.molten.core.mdc.MoltenMDC.initialize(boolean)` in favour of `com.hotels.molten.core.mdc.MoltenMDC.initialize()`.
+- Deprecated `com.hotels.molten.trace.MoltenTrace.initialize(boolean)` in favour of `com.hotels.molten.trace.MoltenTrace.initialize()`.
 
 ## [1.2.3]
 - Only dependency version updates.

--- a/molten-core/src/main/java/com/hotels/molten/core/MoltenCore.java
+++ b/molten-core/src/main/java/com/hotels/molten/core/MoltenCore.java
@@ -33,12 +33,15 @@ import reactor.util.Loggers;
 /**
  * Initializer for Molten. Does the followings:
  * <ul>
- * <li>Initializes SLF4J logging</li>
- * <li>Can enable {@link reactor.core.scheduler.Scheduler} metrics (requires Micrometer).</li>
+ *   <li>Initializes SLF4J logging</li>
+ *   <li>Can enable {@link reactor.core.scheduler.Scheduler} metrics (requires Micrometer).</li>
  * </ul>
  *
- * For specific context propagation see the associated integration. e.g. {@link com.hotels.molten.core.mdc.MoltenMDC}.
- * Certain threading scenarios require explicit propagation solutions.
+ * Molten also provides a convenient and efficient way to manually propagate context at:
+ * <ul>
+ *   <li>Reactor boundaries (thread switching scenarios outside of Reactor's control)</li>
+ *   <li>when the current context needs to be restored (e.g. request collapsing).</li>
+ * </ul>
  * Context propagators can be registered with {@link MoltenCore#registerContextPropagator(String, Function)} and used with {@link MoltenCore#propagateContext()}.
  */
 @Slf4j
@@ -75,6 +78,7 @@ public final class MoltenCore {
         if (INITIALIZED.get()) {
             CONTEXT_PROPAGATORS.clear();
             Hooks.resetOnEachOperator();
+            Hooks.removeQueueWrappers();
             Schedulers.resetOnScheduleHooks();
             INITIALIZED.set(false);
         }

--- a/molten-core/src/main/java/com/hotels/molten/core/MoltenCore.java
+++ b/molten-core/src/main/java/com/hotels/molten/core/MoltenCore.java
@@ -77,7 +77,6 @@ public final class MoltenCore {
     public static void uninitialize() {
         if (INITIALIZED.get()) {
             CONTEXT_PROPAGATORS.clear();
-            Hooks.resetOnEachOperator();
             Hooks.removeQueueWrappers();
             Schedulers.resetOnScheduleHooks();
             INITIALIZED.set(false);

--- a/molten-core/src/main/java/com/hotels/molten/core/common/ContextPropagatorQueue.java
+++ b/molten-core/src/main/java/com/hotels/molten/core/common/ContextPropagatorQueue.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2020 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hotels.molten.core.common;
+
+import java.util.AbstractQueue;
+import java.util.Iterator;
+import java.util.Queue;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * A queue which wraps a delegate queue and saves context information for each added element. The context is restored when the element is retrieved from the queue.
+ *
+ * @param <CONTEXT> the type of context to propagate
+ */
+@SuppressWarnings("unchecked")
+@RequiredArgsConstructor
+public abstract class ContextPropagatorQueue<CONTEXT> extends AbstractQueue<Object> {
+    @NonNull
+    private final Queue<Object> delegate;
+
+    /**
+     * Gets the context to be saved.
+     *
+     * @return the context, might be null
+     */
+    protected abstract CONTEXT retrieveContext();
+
+    /**
+     * Restore the saved context.
+     *
+     * @param context the context to restore, might be null
+     */
+    protected abstract void restoreContext(CONTEXT context);
+
+    @Override
+    public boolean offer(Object o) {
+        return delegate.offer(new ElementWithContext<>(o, retrieveContext()));
+    }
+
+    @Override
+    public Object poll() {
+        return restoreContextAndGetElement(delegate.poll());
+    }
+
+    @Override
+    public Object peek() {
+        return restoreContextAndGetElement(delegate.peek());
+    }
+
+    @Override
+    public int size() {
+        return delegate.size();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Iterator<Object> iterator() {
+        Iterator<?> iterator = delegate.iterator();
+        return new Iterator<>() {
+            @Override
+            public boolean hasNext() {
+                return iterator.hasNext();
+            }
+
+            @Override
+            public Object next() {
+                return restoreContextAndGetElement(iterator.next());
+            }
+        };
+    }
+
+    private Object restoreContextAndGetElement(Object wrappedElement) {
+        var element = wrappedElement;
+        if (wrappedElement instanceof ContextPropagatorQueue.ElementWithContext) {
+            var elementWithContext = (ElementWithContext<CONTEXT>) wrappedElement;
+            restoreContext(elementWithContext.context);
+            element = elementWithContext.element;
+        }
+        return element;
+    }
+
+    @RequiredArgsConstructor
+    private static final class ElementWithContext<CONTEXT> {
+        @NonNull
+        private final Object element;
+        private final CONTEXT context;
+    }
+}
+

--- a/molten-core/src/main/java/com/hotels/molten/core/mdc/MdcContextPropagatingQueue.java
+++ b/molten-core/src/main/java/com/hotels/molten/core/mdc/MdcContextPropagatingQueue.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hotels.molten.core.mdc;
+
+import java.util.Map;
+import java.util.Queue;
+
+import lombok.NonNull;
+import org.slf4j.MDC;
+
+import com.hotels.molten.core.common.ContextPropagatorQueue;
+
+/**
+ * Propagates MDC context when adding and retrieving elements from queue.
+ * Note that the MDC is cleared if there were no context saved when retrieving elements.
+ */
+public class MdcContextPropagatingQueue extends ContextPropagatorQueue<Map<String, String>> {
+
+    public MdcContextPropagatingQueue(@NonNull Queue<Object> delegate) {
+        super(delegate);
+    }
+
+    @Override
+    protected Map<String, String> retrieveContext() {
+        return MDC.getCopyOfContextMap();
+    }
+
+    @Override
+    protected void restoreContext(Map<String, String> savedMdc) {
+        if (savedMdc != null) {
+            MDC.setContextMap(savedMdc);
+        } else {
+            MDC.clear();
+        }
+    }
+}

--- a/molten-core/src/main/java/com/hotels/molten/core/mdc/MoltenMDC.java
+++ b/molten-core/src/main/java/com/hotels/molten/core/mdc/MoltenMDC.java
@@ -58,6 +58,17 @@ public final class MoltenMDC {
     }
 
     /**
+     * Initializes MDC propagation in Reactor.
+     *
+     * @param unused unused parameter
+     * @deprecated use {@link #initialize()}
+     */
+    @Deprecated
+    public static void initialize(boolean unused) {
+        initialize();
+    }
+
+    /**
      * Reset all Molten MDC - Reactor integration.
      */
     public static void uninitialize() {

--- a/molten-core/src/main/java/com/hotels/molten/core/mdc/MoltenMDC.java
+++ b/molten-core/src/main/java/com/hotels/molten/core/mdc/MoltenMDC.java
@@ -19,6 +19,7 @@ package com.hotels.molten.core.mdc;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Map;
+import java.util.Queue;
 import java.util.function.Function;
 
 import lombok.extern.slf4j.Slf4j;
@@ -43,35 +44,17 @@ public final class MoltenMDC {
     }
 
     /**
-     * Initializes MDC propagation in Reactor with explicit propagation.
-     * See {@code initialize(false)} for more information.
-     */
-    public static void initialize() {
-        initialize(false);
-    }
-
-    /**
      * Initializes MDC propagation in Reactor.
-     * Ensures MDC is propagated when switching scheduler threads or at specific thread switching scenarios.
-     * <p>
-     * Depending on {@code onEachOperator} there are two different behaviours.
-     * <br>
-     * When it is set to {@code true} the MDC values at creation time will be maintained throughout the flow.
-     * Changes in the MDC won't be reflected downstream.
-     * <br>
-     * When it is set to {@code false} the MDC value changes will be propagated at flow execution time where explicitly done with {@link MoltenCore#propagateContext()}.
      *
-     * @param onEachOperator whether to decorate all operator (at creation time) to propagate MDC or use explicit context propagation.
+     * Ensures MDC is propagated when switching schedulers or when queueing and retrieving tasks in Reactor.
      */
-    public static void initialize(boolean onEachOperator) {
+    @SuppressWarnings("unchecked")
+    public static void initialize() {
         uninitialize();
-        LOG.info("Integrating MDC with Molten onEachOperator={}", onEachOperator);
+        LOG.info("Integrating MDC with Molten");
         Schedulers.onScheduleHook(HOOK_KEY, MDCCopyingAction::new);
-        if (onEachOperator) {
-            Hooks.onEachOperator(HOOK_KEY, propagate());
-        } else {
-            MoltenCore.registerContextPropagator(HOOK_KEY, MoltenMDC.propagate()::apply);
-        }
+        Hooks.addQueueWrapper(HOOK_KEY, q -> new MdcContextPropagatingQueue((Queue<Object>) q));
+        MoltenCore.registerContextPropagator(HOOK_KEY, MoltenMDC.propagate()::apply);
     }
 
     /**
@@ -79,7 +62,7 @@ public final class MoltenMDC {
      */
     public static void uninitialize() {
         MoltenCore.resetContextPropagator(HOOK_KEY);
-        Hooks.resetOnEachOperator(HOOK_KEY);
+        Hooks.removeQueueWrapper(HOOK_KEY);
         Schedulers.resetOnScheduleHook(HOOK_KEY);
     }
 

--- a/molten-core/src/test/java/com/hotels/molten/core/common/ContextPropagatorQueueTest.java
+++ b/molten-core/src/test/java/com/hotels/molten/core/common/ContextPropagatorQueueTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2020 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hotels.molten.core.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Queue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import lombok.NonNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit test for {@link ContextPropagatorQueue}.
+ */
+@ExtendWith(MockitoExtension.class)
+class ContextPropagatorQueueTest {
+    public static final String ELEMENT = "element";
+    public static final String ELEMENT_2 = "element_2";
+    @Mock
+    DummyContext context;
+    @Mock
+    DummyContextHandler contextHandler;
+    DummyContextPropagatorQueue contextPropagatorQueue = new DummyContextPropagatorQueue(new LinkedBlockingQueue<>());
+
+    @Test
+    void should_save_and_restore_context_for_offer_and_poll() {
+        when(contextHandler.retrieve()).thenReturn(context);
+        contextPropagatorQueue.offer(ELEMENT);
+        verify(contextHandler).retrieve();
+        verifyNoMoreInteractions(contextHandler);
+        assertThat(contextPropagatorQueue.poll()).isEqualTo(ELEMENT);
+        verify(contextHandler).restore(context);
+    }
+
+    @Test
+    void should_save_and_restore_context_for_offer_and_peek() {
+        when(contextHandler.retrieve()).thenReturn(context);
+        contextPropagatorQueue.offer(ELEMENT);
+        verify(contextHandler).retrieve();
+        verifyNoMoreInteractions(contextHandler);
+        assertThat(contextPropagatorQueue.peek()).isEqualTo(ELEMENT);
+        verify(contextHandler).restore(context);
+        assertThat(contextPropagatorQueue.peek()).isEqualTo(ELEMENT);
+        verify(contextHandler, times(2)).restore(context);
+    }
+
+    @Test
+    void should_save_and_restore_context_for_offer_and_iterator() {
+        when(contextHandler.retrieve()).thenReturn(context);
+        contextPropagatorQueue.offer(ELEMENT);
+        verify(contextHandler).retrieve();
+        assertThat(contextPropagatorQueue.size()).isEqualTo(1);
+        contextPropagatorQueue.offer(ELEMENT_2);
+        verify(contextHandler, times(2)).retrieve();
+        assertThat(contextPropagatorQueue.size()).isEqualTo(2);
+        verifyNoMoreInteractions(contextHandler);
+        var iterator = contextPropagatorQueue.iterator();
+        assertThat(iterator.next()).isEqualTo(ELEMENT);
+        verify(contextHandler).restore(context);
+        assertThat(iterator.next()).isEqualTo(ELEMENT_2);
+        verify(contextHandler, times(2)).restore(context);
+    }
+
+    class DummyContextPropagatorQueue extends ContextPropagatorQueue<DummyContext> {
+        DummyContextPropagatorQueue(@NonNull Queue<Object> delegate) {
+            super(delegate);
+        }
+
+        @Override
+        protected DummyContext retrieveContext() {
+            return contextHandler.retrieve();
+        }
+
+        @Override
+        protected void restoreContext(DummyContext context) {
+            contextHandler.restore(context);
+        }
+    }
+
+    interface DummyContext {
+    }
+
+    interface DummyContextHandler {
+
+        DummyContext retrieve();
+
+        void restore(DummyContext context);
+    }
+}

--- a/molten-core/src/test/java/com/hotels/molten/core/mdc/MdcContextPropagatingQueueTest.java
+++ b/molten-core/src/test/java/com/hotels/molten/core/mdc/MdcContextPropagatingQueueTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2020 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hotels.molten.core.mdc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.MDC;
+
+/**
+ * Unit test for {@link MdcContextPropagatingQueue}.
+ */
+@ExtendWith(MockitoExtension.class)
+class MdcContextPropagatingQueueTest {
+    public static final String KEY = "key";
+    public static final String VALUE = "value";
+    public static final String SOMETHING = "something";
+
+    @BeforeEach
+    @AfterEach
+    void initContext() {
+        MDC.clear();
+    }
+
+    @Test
+    void should_propagate_mdc_with_element() {
+        //Given
+        var queue = new MdcContextPropagatingQueue(new LinkedBlockingQueue<>());
+        MDC.put(KEY, VALUE);
+        //When
+        queue.offer(SOMETHING);
+        MDC.clear();
+        assertThat(MDC.getCopyOfContextMap()).isNull();
+        assertThat(queue.poll()).isEqualTo(SOMETHING);
+        //Then
+        assertThat(MDC.get(KEY)).isEqualTo(VALUE);
+    }
+}

--- a/molten-spring-boot/src/main/java/com/hotels/molten/spring/boot/MoltenCoreSpringBootInitializer.java
+++ b/molten-spring-boot/src/main/java/com/hotels/molten/spring/boot/MoltenCoreSpringBootInitializer.java
@@ -31,7 +31,7 @@ public class MoltenCoreSpringBootInitializer implements ApplicationListener<Appl
     @Override
     public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
         MoltenCore.initialize();
-        MoltenMDC.initialize(false);
+        MoltenMDC.initialize();
         MoltenMetrics.setDimensionalMetricsEnabled(true);
     }
 }

--- a/molten-trace-test/src/test/java/com/hotels/molten/trace/MoltenTraceTest.java
+++ b/molten-trace-test/src/test/java/com/hotels/molten/trace/MoltenTraceTest.java
@@ -27,7 +27,6 @@ import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
 
 import brave.Tracing;
 import lombok.SneakyThrows;
@@ -39,8 +38,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 import reactor.core.publisher.Hooks;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -89,14 +86,8 @@ public class MoltenTraceTest {
         TracingTestSupport.cleanUp();
     }
 
-    static Stream<Boolean> onEachOperatorEnabled() {
-        return Stream.of(true, false);
-    }
-
-    @ParameterizedTest
-    @MethodSource("onEachOperatorEnabled")
-    void should_support_nesting(boolean onEachOperatorEnabled) {
-        MoltenTrace.initialize(onEachOperatorEnabled);
+    @Test
+    void should_support_nesting() {
         try (TraceSpan outer = Tracer.span("outer").start()) {
             StepVerifier.create(
                 Mono.just("data")
@@ -109,10 +100,8 @@ public class MoltenTraceTest {
     }
 
     @SneakyThrows
-    @ParameterizedTest
-    @MethodSource("onEachOperatorEnabled")
-    void should_support_fully_reactive_nesting(boolean onEachOperatorEnabled) {
-        MoltenTrace.initialize(onEachOperatorEnabled);
+    @Test
+    void should_support_fully_reactive_nesting() {
         CountDownLatch latch = new CountDownLatch(1);
         StepVerifier.create(
             Mono.just("data")
@@ -146,10 +135,8 @@ public class MoltenTraceTest {
             });
     }
 
-    @ParameterizedTest
-    @MethodSource("onEachOperatorEnabled")
-    void should_propagate_when_switching_schedulers(boolean onEachOperatorEnabled) {
-        MoltenTrace.initialize(onEachOperatorEnabled);
+    @Test
+    void should_propagate_when_switching_schedulers() {
         try (TraceSpan outer = Tracer.span("outer").start()) {
             StepVerifier.create(
                 Mono.just("data")
@@ -163,10 +150,8 @@ public class MoltenTraceTest {
         assertThat(capturedSpans(), contains(spanWithName("inner"), rootSpanWithName("outer")));
     }
 
-    @ParameterizedTest
-    @MethodSource("onEachOperatorEnabled")
-    void should_propagate_when_switching_schedulers_for_subscribe(boolean onEachOperatorEnabled) {
-        MoltenTrace.initialize(onEachOperatorEnabled);
+    @Test
+    void should_propagate_when_switching_schedulers_for_subscribe() {
         try (Tracer.TraceSpan outer = Tracer.span("outer").start()) {
             StepVerifier.create(
                 Mono.just("data")
@@ -180,11 +165,9 @@ public class MoltenTraceTest {
         assertThat(capturedSpans(), contains(spanWithName("inner"), rootSpanWithName("outer")));
     }
 
-    @ParameterizedTest
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    @MethodSource("onEachOperatorEnabled")
-    void should_propagate_trace_context_in_indirect_flow(boolean onEachOperatorEnabled) {
-        MoltenTrace.initialize(onEachOperatorEnabled);
+    @Test
+    void should_propagate_trace_context_in_indirect_flow() {
         try (Tracer.TraceSpan outer = Tracer.span("outer").start()) {
             var outerSpan = Optional.ofNullable(Tracing.currentTracer()).map(brave.Tracer::currentSpan).orElse(null);
             LOG.debug("outer span={}", outerSpan);

--- a/molten-trace/src/main/java/com/hotels/molten/trace/MoltenTrace.java
+++ b/molten-trace/src/main/java/com/hotels/molten/trace/MoltenTrace.java
@@ -57,6 +57,18 @@ public final class MoltenTrace {
     }
 
     /**
+     * Initializes tracing in Reactor.
+     *
+     * @param unused unused parameter
+     * @deprecated use {@link #initialize()}
+     */
+    @Deprecated
+    public static void initialize(boolean unused) {
+        initialize();
+    }
+
+
+    /**
      * Reset all Molten Trace - Reactor integration.
      */
     public static void uninitialize() {

--- a/molten-trace/src/main/java/com/hotels/molten/trace/TraceContextPropagatorQueue.java
+++ b/molten-trace/src/main/java/com/hotels/molten/trace/TraceContextPropagatorQueue.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hotels.molten.trace;
+
+import java.util.Queue;
+
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.TraceContext;
+import lombok.NonNull;
+
+import com.hotels.molten.core.common.ContextPropagatorQueue;
+
+public class TraceContextPropagatorQueue extends ContextPropagatorQueue<TraceContext> {
+    private final CurrentTraceContext currentTraceContext;
+
+    public TraceContextPropagatorQueue(@NonNull Queue<Object> delegate, @NonNull CurrentTraceContext currentTraceContext) {
+        super(delegate);
+        this.currentTraceContext = currentTraceContext;
+    }
+
+    @Override
+    protected TraceContext retrieveContext() {
+        return currentTraceContext.get();
+    }
+
+    @Override
+    protected void restoreContext(TraceContext traceContext) {
+        if (traceContext != null) {
+            currentTraceContext.maybeScope(traceContext);
+        }
+    }
+}


### PR DESCRIPTION
This change replaces the onEach hook based context propagation with a queue hook based one.